### PR TITLE
added material_tag to multimaterial and material classes

### DIFF
--- a/neutronics_material_maker/material_maker_classes.py
+++ b/neutronics_material_maker/material_maker_classes.py
@@ -30,13 +30,10 @@ material values such as density, chemical present etc ."""
 
 __author__ = "Jonathan Shimwell"
 
-import json
-import math
 import re
 
-from CoolProp.CoolProp import PropsSI
-
 import openmc
+from CoolProp.CoolProp import PropsSI
 
 from .all_materials import material_dict
 
@@ -47,6 +44,7 @@ class Material:
         self,
         material_name,
         packing_fraction=1.0,
+        material_tag=None,
         elements=None,
         isotopes=None,
         percent_type=None,
@@ -92,6 +90,7 @@ class Material:
         """
 
         self._material_name = material_name
+        self._material_tag = material_tag
         self._temperature_in_C = temperature_in_C
         self._temperature_in_K = temperature_in_K
         self._pressure_in_Pa = pressure_in_Pa
@@ -162,6 +161,15 @@ class Material:
             raise ValueError("Material names must be a string")
         self._material_name = value
 
+    @property
+    def material_tag(self):
+        return self._material_tag
+
+    @material_tag.setter
+    def material_tag(self, value):
+        if type(value) is not str:
+            raise ValueError("Material tags must be a string")
+        self._material_tag = value
 
     @property
     def packing_fraction(self):
@@ -499,8 +507,8 @@ class Material:
 
 
 class MultiMaterial(list):
-    def __init__(self, material_name, materials=[], fracs=[], percent_type='vo'):
-        self.material_name = material_name
+    def __init__(self, material_tag, materials=[], fracs=[], percent_type='vo'):
+        self.material_tag = material_tag
         self.materials = materials
         self.fracs = fracs
         self.percent_type = percent_type
@@ -523,7 +531,7 @@ class MultiMaterial(list):
 
         print(openmc_material_objects)
 
-        self.neutronics_material = openmc.Material.mix_materials(name = self.material_name,
+        self.neutronics_material = openmc.Material.mix_materials(name = self.material_tag,
                                                                  materials = openmc_material_objects,
                                                                  fracs = self.fracs,
                                                                  percent_type = self.percent_type)

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -59,8 +59,8 @@ class test_object_properties(unittest.TestCase):
 
                 assert isinstance(test_material, openmc.Material) == False
                 assert isinstance(test_material.neutronics_material, openmc.Material) == True
-                
-        
+
+
         def test_make_multimaterial_from_neutronics_materials(self):
             # tests that a multimaterial can be created by passing neutronics materials into the MultiMaterial function
 
@@ -75,7 +75,7 @@ class test_object_properties(unittest.TestCase):
             assert isinstance(test_material, openmc.Material) == False
             assert isinstance(test_material.neutronics_material, openmc.Material) == True
 
-        
+
         def test_multimaterial_attributes_from_material_objects_and_neutronics_materials(self):
             # tests that multimaterials made from material objects and neutronics materials have the same properties
 
@@ -95,10 +95,10 @@ class test_object_properties(unittest.TestCase):
                                             fracs = [0.5, 0.5],
                                             percent_type = 'vo').neutronics_material
 
-            
+
             assert test_material_1.density == test_material_2.density
             assert test_material_1.nuclides == test_material_2.nuclides
-            
+
 
         def test_density_of_mixed_two_packed_crystals(self): 
 
@@ -110,7 +110,7 @@ class test_object_properties(unittest.TestCase):
                 test_material_packed_2 = Material(material_name="Be12Ti", packing_fraction=0.35)
                 assert test_material_2.neutronics_material.density * 0.35 == test_material_packed_2.neutronics_material.density
 
-                mixed_packed_crystals = MultiMaterial(material_name = 'mixed_packed_crystals',
+                mixed_packed_crystals = MultiMaterial(material_tag = 'mixed_packed_crystals',
                                                       materials = [test_material_packed_1, test_material_packed_2],
                                                       fracs = [0.75,0.25],
                                                       percent_type = 'vo')
@@ -123,7 +123,7 @@ class test_object_properties(unittest.TestCase):
                 test_material_1 = Material(material_name='Li4SiO4')
                 test_material_1_packed = Material(material_name='Li4SiO4', packing_fraction=0.65)
 
-                mixed_material = MultiMaterial(material_name = 'mixed_material',
+                mixed_material = MultiMaterial(material_tag = 'mixed_material',
                                                materials = [test_material_1, test_material_1_packed],
                                                fracs = [0.2, 0.8],
                                                percent_type = 'vo')
@@ -134,7 +134,7 @@ class test_object_properties(unittest.TestCase):
         def test_density_of_mixed_materials_from_density_equation(self):
 
                 test_material = Material('H2O', temperature_in_C=25, pressure_in_Pa=100000)  
-                test_mixed_material = MultiMaterial(material_name = 'test_mixed_material', materials= [test_material], fracs=[1])
+                test_mixed_material = MultiMaterial(material_tag = 'test_mixed_material', materials= [test_material], fracs=[1])
 
                 assert test_material.neutronics_material.density ==  test_mixed_material.neutronics_material.density
 
@@ -146,7 +146,7 @@ class test_object_properties(unittest.TestCase):
                 test_material_2 = Material(material_name="Li4SiO4")
                 test_material_2_packed = Material(material_name="Li4SiO4", packing_fraction=0.65)
 
-                mixed_packed_crystal_and_non_crystal = MultiMaterial(material_name = 'mixed_packed_crystal_and_non_crystal',
+                mixed_packed_crystal_and_non_crystal = MultiMaterial(material_tag = 'mixed_packed_crystal_and_non_crystal',
                                                                      materials = [test_material_1, test_material_2_packed],
                                                                      fracs = [0.5, 0.5],
                                                                      percent_type = 'vo')
@@ -155,7 +155,7 @@ class test_object_properties(unittest.TestCase):
 
 
         def test_packing_fraction_for_single_materials(self):
-            
+
             test_material_1 = Material('Li4SiO4').neutronics_material
 
             test_material_2 = Material('Li4SiO4', packing_fraction=1).neutronics_material
@@ -169,7 +169,7 @@ class test_object_properties(unittest.TestCase):
             test_material_4 = Material('Li4SiO4', packing_fraction=0.75).neutronics_material
 
             assert test_material_4.density == pytest.approx(test_material_1.density * 0.75)
-            
+
 
         def test_packing_fraction_for_multimaterial_function(self):
 
@@ -296,7 +296,3 @@ class test_object_properties(unittest.TestCase):
                                     percent_type = 'vo')
 
             assert test_material_13.density == test_material_14.density
-
-
-
-            


### PR DESCRIPTION
This PR changes the material_name argument in multimaterial to material_tag and also introduces another argument for material called material_tag.

these material_tag properties will be used by dagmc to identify the material and therefore it is sometimes needed to have a different tag to the name of the material