### PR TITLE
replaced neutronics_material with openmc_material

### DIFF
--- a/neutronics_material_maker/material_maker_classes.py
+++ b/neutronics_material_maker/material_maker_classes.py
@@ -112,7 +112,7 @@ class Material:
         self.enrichment_element = None
         self.density_packed = None
 
-        self.neutronics_material = None
+        self.openmc_material = None
         self.list_of_fractions = None
         self.chemical_equation = None
         self.element_numbers = None
@@ -401,7 +401,7 @@ class Material:
             for element_symbol, element_number in zip(self.elements.keys(), self.elements.values()):
 
                 if element_symbol == enrichment_element:
-                    self.neutronics_material.add_element(element_symbol,
+                    self.openmc_material.add_element(element_symbol,
                                                          element_number,
                                                          percent_type=self.percent_type,
                                                          enrichment=self.enrichment,
@@ -409,7 +409,7 @@ class Material:
                                                          enrichment_type=self.enrichment_type
                                                          )
                 else:
-                    self.neutronics_material.add_element(element_symbol,
+                    self.openmc_material.add_element(element_symbol,
                                                          element_number,
                                                          self.percent_type
                                                         )
@@ -418,7 +418,7 @@ class Material:
 
             self.chemical_equation = self.elements
 
-            self.neutronics_material.add_elements_from_formula(self.elements,
+            self.openmc_material.add_elements_from_formula(self.elements,
                                                               percent_type=self.percent_type,
                                                               enrichment=self.enrichment,
                                                               enrichment_target=self.enrichment_target,
@@ -429,7 +429,7 @@ class Material:
 
         for isotope_symbol, isotope_number in zip(self.isotopes.keys(), self.isotopes.values()):
 
-            self.neutronics_material.add_nuclide(isotope_symbol, isotope_number, self.percent_type)
+            self.openmc_material.add_nuclide(isotope_symbol, isotope_number, self.percent_type)
 
 
     def add_density(self):
@@ -452,7 +452,7 @@ class Material:
 
         elif self.atoms_per_unit_cell != None and self.volume_of_unit_cell_cm3 != None:
 
-            molar_mass = self.get_atoms_in_crystal() * self.neutronics_material.average_molar_mass
+            molar_mass = self.get_atoms_in_crystal() * self.openmc_material.average_molar_mass
 
             mass = self.atoms_per_unit_cell * molar_mass * atomic_mass_unit_in_g
 
@@ -464,13 +464,13 @@ class Material:
                 " provide either a density value, equation as a string, or atoms_per_unit_cell and volume_of_unit_cell_cm3",
             )
 
-        self.neutronics_material.set_density(self.density_unit, self.density * self.packing_fraction)
+        self.openmc_material.set_density(self.density_unit, self.density * self.packing_fraction)
 
-        return self.neutronics_material
+        return self.openmc_material
 
     def make_material(self):
 
-        self.neutronics_material = openmc.Material(name=self.material_name)
+        self.openmc_material = openmc.Material(name=self.material_name)
 
         if self.isotopes is not None:
 
@@ -512,7 +512,7 @@ class MultiMaterial(list):
         self.materials = materials
         self.fracs = fracs
         self.percent_type = percent_type
-        self.neutronics_material = None
+        self.openmc_material = None
 
         self.make_material()
 
@@ -527,9 +527,9 @@ class MultiMaterial(list):
             if isinstance(material, openmc.Material) == True:
                 openmc_material_objects.append(material)
             else:
-                openmc_material_objects.append(material.neutronics_material)
+                openmc_material_objects.append(material.openmc_material)
 
-        self.neutronics_material = openmc.Material.mix_materials(name = self.material_tag,
+        self.openmc_material = openmc.Material.mix_materials(name = self.material_tag,
                                                                  materials = openmc_material_objects,
                                                                  fracs = self.fracs,
                                                                  percent_type = self.percent_type)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1235.33",
+    version="0.1235.35",
     summary='Package for making material cards for OpenMC',
     author="Jonathan Shimwell",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,6 +3,6 @@ import openmc
 
 from neutronics_material_maker import Material 
 
-test_material = Material(material_name='Li4SiO4', enrichment=50, enrichment_target='Li6', enrichment_type='ao').neutronics_material
+test_material = Material(material_name='Li4SiO4', enrichment=50, enrichment_target='Li6', enrichment_type='ao').openmc_material
 
 print(test_material)

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -41,7 +41,7 @@ class test_object_properties(unittest.TestCase):
                 test_material = Material('lithium-lead',
                                          elements=lithium_lead_elements,
                                          temperature_in_C=450)
-                nucs = test_material.neutronics_material.nuclides
+                nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
                 for entry in nucs:
@@ -65,7 +65,7 @@ class test_object_properties(unittest.TestCase):
                                          enrichment_type='ao',
                                          elements=lithium_lead_elements,
                                          temperature_in_C=450)
-                nucs = test_material.neutronics_material.nuclides
+                nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
                 li6_atom_count = 0
@@ -92,37 +92,37 @@ class test_object_properties(unittest.TestCase):
                 # however, this could be becuase the density values are rounded to 2 dp
 
                 test_material = Material(material_name="Li4SiO4")
-                assert test_material.neutronics_material.density == pytest.approx(2.32, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(2.32, rel=0.01)
 
                 test_material = Material(material_name="Li2SiO3")
-                assert test_material.neutronics_material.density == pytest.approx(2.44, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(2.44, rel=0.01)
 
                 test_material = Material(material_name="Li2ZrO3")
-                assert test_material.neutronics_material.density == pytest.approx(4.03, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(4.03, rel=0.01)
 
                 test_material = Material(material_name="Li2TiO3")
-                assert test_material.neutronics_material.density == pytest.approx(3.34, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(3.34, rel=0.01)
 
                 test_material = Material(material_name="Li8PbO6")
-                assert test_material.neutronics_material.density == pytest.approx(4.14, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(4.14, rel=0.01)
 
                 test_material = Material(material_name="Be")
-                assert test_material.neutronics_material.density == pytest.approx(1.88, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(1.88, rel=0.01)
 
                 test_material = Material(material_name="Be12Ti")
-                assert test_material.neutronics_material.density == pytest.approx(2.28, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(2.28, rel=0.01)
 
                 test_material = Material(material_name="Ba5Pb3")
-                assert test_material.neutronics_material.density == pytest.approx(5.84, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(5.84, rel=0.01)
 
                 test_material = Material(material_name="Nd5Pb4")
-                assert test_material.neutronics_material.density == pytest.approx(8.79, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(8.79, rel=0.01)
 
                 test_material = Material(material_name="Zr5Pb3")
-                assert test_material.neutronics_material.density == pytest.approx(8.23, rel=0.01)
+                assert test_material.openmc_material.density == pytest.approx(8.23, rel=0.01)
 
                 # test_material = Material(material_name="Zr5Pb4")
-                # assert test_material.neutronics_material.density == pytest.approx(#insert)
+                # assert test_material.openmc_material.density == pytest.approx(#insert)
 
                 #  TODO extra checks for all the crystals needed here
 
@@ -131,7 +131,7 @@ class test_object_properties(unittest.TestCase):
                 test_material = Material(material_name="Li4SiO4")
                 test_material_enriched = Material(material_name="Li4SiO4", enrichment=50., enrichment_target='Li6',
                                          enrichment_type='ao',)
-                assert test_material.neutronics_material.density > test_material_enriched.neutronics_material.density
+                assert test_material.openmc_material.density > test_material_enriched.openmc_material.density
 
 
 
@@ -139,7 +139,7 @@ class test_object_properties(unittest.TestCase):
 
                 test_material = Material(material_name="Li4SiO4")
                 test_material_packed = Material(material_name="Li4SiO4", packing_fraction=0.35)
-                assert test_material.neutronics_material.density * 0.35 == test_material_packed.neutronics_material.density
+                assert test_material.openmc_material.density * 0.35 == test_material_packed.openmc_material.density
 
 
 
@@ -152,7 +152,7 @@ class test_object_properties(unittest.TestCase):
                 test_material = Material('lithium-lead',
                                          elements=lithium_lead_elements,
                                          temperature_in_C=450)
-                nucs = test_material.neutronics_material.nuclides
+                nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
                 for entry in nucs:
@@ -176,7 +176,7 @@ class test_object_properties(unittest.TestCase):
                                          enrichment_type='ao',
                                          elements=lithium_lead_elements,
                                          temperature_in_C=450)
-                nucs = test_material.neutronics_material.nuclides
+                nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
                 li6_atom_count = 0

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -58,25 +58,25 @@ class test_object_properties(unittest.TestCase):
                                               percent_type = 'vo')
 
                 assert isinstance(test_material, openmc.Material) == False
-                assert isinstance(test_material.neutronics_material, openmc.Material) == True
+                assert isinstance(test_material.openmc_material, openmc.Material) == True
 
 
-        def test_make_multimaterial_from_neutronics_materials(self):
+        def test_make_multimaterial_from_openmc_materials(self):
             # tests that a multimaterial can be created by passing neutronics materials into the MultiMaterial function
 
             test_material = MultiMaterial('test_material',
                                           materials = [
-                                              Material('Li4SiO4').neutronics_material,
-                                              Material('Be12Ti').neutronics_material
+                                              Material('Li4SiO4').openmc_material,
+                                              Material('Be12Ti').openmc_material
                                           ],
                                           fracs = [0.50, 0.50],
                                           percent_type = 'vo')
 
             assert isinstance(test_material, openmc.Material) == False
-            assert isinstance(test_material.neutronics_material, openmc.Material) == True
+            assert isinstance(test_material.openmc_material, openmc.Material) == True
 
 
-        def test_multimaterial_attributes_from_material_objects_and_neutronics_materials(self):
+        def test_multimaterial_attributes_from_material_objects_and_openmc_materials(self):
             # tests that multimaterials made from material objects and neutronics materials have the same properties
 
             test_material_1 = MultiMaterial('test_material_1',
@@ -85,15 +85,15 @@ class test_object_properties(unittest.TestCase):
                                                 Material('Be12Ti')
                                             ],
                                             fracs = [0.5, 0.5],
-                                            percent_type = 'vo').neutronics_material
+                                            percent_type = 'vo').openmc_material
 
             test_material_2 = MultiMaterial('test_material_2',
                                             materials = [
-                                                Material('Li4SiO4').neutronics_material,
-                                                Material('Be12Ti').neutronics_material
+                                                Material('Li4SiO4').openmc_material,
+                                                Material('Be12Ti').openmc_material
                                             ],
                                             fracs = [0.5, 0.5],
-                                            percent_type = 'vo').neutronics_material
+                                            percent_type = 'vo').openmc_material
 
 
             assert test_material_1.density == test_material_2.density
@@ -104,18 +104,18 @@ class test_object_properties(unittest.TestCase):
 
                 test_material_1 = Material(material_name="Li4SiO4")
                 test_material_packed_1 = Material(material_name="Li4SiO4", packing_fraction=0.65)
-                assert test_material_1.neutronics_material.density * 0.65 == test_material_packed_1.neutronics_material.density
+                assert test_material_1.openmc_material.density * 0.65 == test_material_packed_1.openmc_material.density
 
                 test_material_2 = Material(material_name="Be12Ti")
                 test_material_packed_2 = Material(material_name="Be12Ti", packing_fraction=0.35)
-                assert test_material_2.neutronics_material.density * 0.35 == test_material_packed_2.neutronics_material.density
+                assert test_material_2.openmc_material.density * 0.35 == test_material_packed_2.openmc_material.density
 
                 mixed_packed_crystals = MultiMaterial(material_tag = 'mixed_packed_crystals',
                                                       materials = [test_material_packed_1, test_material_packed_2],
                                                       fracs = [0.75,0.25],
                                                       percent_type = 'vo')
 
-                assert mixed_packed_crystals.neutronics_material.density == pytest.approx( (test_material_1.neutronics_material.density * 0.65 * 0.75) + (test_material_2.neutronics_material.density * 0.35 * 0.25), rel=0.01)
+                assert mixed_packed_crystals.openmc_material.density == pytest.approx( (test_material_1.openmc_material.density * 0.65 * 0.75) + (test_material_2.openmc_material.density * 0.35 * 0.25), rel=0.01)
 
 
         def test_density_of_mixed_two_packed_and_non_packed_crystals(self):
@@ -128,7 +128,7 @@ class test_object_properties(unittest.TestCase):
                                                fracs = [0.2, 0.8],
                                                percent_type = 'vo')
 
-                assert mixed_material.neutronics_material.density == pytest.approx((test_material_1.neutronics_material.density * 0.2) + (test_material_1.neutronics_material.density * 0.65 * 0.8))
+                assert mixed_material.openmc_material.density == pytest.approx((test_material_1.openmc_material.density * 0.2) + (test_material_1.openmc_material.density * 0.65 * 0.8))
 
 
         def test_density_of_mixed_materials_from_density_equation(self):
@@ -136,7 +136,7 @@ class test_object_properties(unittest.TestCase):
                 test_material = Material('H2O', temperature_in_C=25, pressure_in_Pa=100000)  
                 test_mixed_material = MultiMaterial(material_tag = 'test_mixed_material', materials= [test_material], fracs=[1])
 
-                assert test_material.neutronics_material.density ==  test_mixed_material.neutronics_material.density
+                assert test_material.openmc_material.density ==  test_mixed_material.openmc_material.density
 
 
         def test_density_of_mixed_one_packed_crystal_and_one_non_crystal(self):
@@ -151,22 +151,22 @@ class test_object_properties(unittest.TestCase):
                                                                      fracs = [0.5, 0.5],
                                                                      percent_type = 'vo')
 
-                assert mixed_packed_crystal_and_non_crystal.neutronics_material.density == pytest.approx( (test_material_1.neutronics_material.density * 0.5) + (test_material_2.neutronics_material.density * 0.65 * 0.5) )
+                assert mixed_packed_crystal_and_non_crystal.openmc_material.density == pytest.approx( (test_material_1.openmc_material.density * 0.5) + (test_material_2.openmc_material.density * 0.65 * 0.5) )
 
 
         def test_packing_fraction_for_single_materials(self):
 
-            test_material_1 = Material('Li4SiO4').neutronics_material
+            test_material_1 = Material('Li4SiO4').openmc_material
 
-            test_material_2 = Material('Li4SiO4', packing_fraction=1).neutronics_material
+            test_material_2 = Material('Li4SiO4', packing_fraction=1).openmc_material
 
             assert test_material_1.density == test_material_2.density
 
-            test_material_3 = Material('Li4SiO4', packing_fraction=0.5).neutronics_material
+            test_material_3 = Material('Li4SiO4', packing_fraction=0.5).openmc_material
 
             assert test_material_3.density == pytest.approx(test_material_1.density * 0.5)
 
-            test_material_4 = Material('Li4SiO4', packing_fraction=0.75).neutronics_material
+            test_material_4 = Material('Li4SiO4', packing_fraction=0.75).openmc_material
 
             assert test_material_4.density == pytest.approx(test_material_1.density * 0.75)
 
@@ -181,7 +181,7 @@ class test_object_properties(unittest.TestCase):
                                     fracs = [
                                         0.5, 
                                         0.5
-                                    ]).neutronics_material
+                                    ]).openmc_material
 
             test_material_6 = MultiMaterial('test_material_6',
                                     materials = [
@@ -191,7 +191,7 @@ class test_object_properties(unittest.TestCase):
                                     fracs = [
                                         0.5,
                                         0.5
-                                    ]).neutronics_material
+                                    ]).openmc_material
 
             assert test_material_5.density == test_material_6.density
 
@@ -204,7 +204,7 @@ class test_object_properties(unittest.TestCase):
                                     fracs = [
                                         0.5,
                                         0.5
-                                    ]).neutronics_material
+                                    ]).openmc_material
 
             assert test_material_7.density == pytest.approx(test_material_5.density * 0.5)
 
@@ -213,8 +213,8 @@ class test_object_properties(unittest.TestCase):
 
             test_material_8 = openmc.Material.mix_materials(name='test_material_8',
                                     materials = [
-                                        Material('tungsten').neutronics_material,
-                                        Material('eurofer').neutronics_material
+                                        Material('tungsten').openmc_material,
+                                        Material('eurofer').openmc_material
                                     ],
                                     fracs = [
                                         0.5,
@@ -224,8 +224,8 @@ class test_object_properties(unittest.TestCase):
 
             test_material_9 = openmc.Material.mix_materials(name='test_material_9',
                                     materials = [
-                                        Material('tungsten', packing_fraction=1).neutronics_material,
-                                        Material('eurofer', packing_fraction=1).neutronics_material 
+                                        Material('tungsten', packing_fraction=1).openmc_material,
+                                        Material('eurofer', packing_fraction=1).openmc_material 
                                     ],
                                     fracs = [
                                         0.5,
@@ -237,8 +237,8 @@ class test_object_properties(unittest.TestCase):
 
             test_material_10 = openmc.Material.mix_materials(name='test_material_10',
                                     materials = [
-                                        Material('tungsten', packing_fraction=0.5).neutronics_material,
-                                        Material('eurofer', packing_fraction=0.5).neutronics_material 
+                                        Material('tungsten', packing_fraction=0.5).openmc_material,
+                                        Material('eurofer', packing_fraction=0.5).openmc_material 
                                     ],
                                     fracs = [
                                         0.5,
@@ -259,12 +259,12 @@ class test_object_properties(unittest.TestCase):
                                     fracs = [
                                         0.5,
                                         0.5
-                                    ]).neutronics_material
+                                    ]).openmc_material
 
             test_material_12 = openmc.Material.mix_materials(name='test_material_12',
                                     materials = [
-                                        Material('tungsten').neutronics_material,
-                                        Material('eurofer').neutronics_material
+                                        Material('tungsten').openmc_material,
+                                        Material('eurofer').openmc_material
                                     ],
                                     fracs = [
                                         0.5,
@@ -282,12 +282,12 @@ class test_object_properties(unittest.TestCase):
                                     fracs = [
                                         0.3,
                                         0.7
-                                    ]).neutronics_material
+                                    ]).openmc_material
 
             test_material_14 = openmc.Material.mix_materials(name='test_material_14',
                                     materials = [
-                                        Material('tungsten', packing_fraction=0.6).neutronics_material,
-                                        Material('eurofer', packing_fraction=0.8).neutronics_material
+                                        Material('tungsten', packing_fraction=0.6).openmc_material,
+                                        Material('eurofer', packing_fraction=0.8).openmc_material
                                     ],
                                     fracs = [
                                         0.3,


### PR DESCRIPTION
This PR changes the name of the .neutronics_material to .openmc_material.

This is a small change to which allows future codes to be supported such as openmoc, mcnp, serpent etc

Once a pip install is available for openmc then working on these other materials should be possible

