### PR TITLE
added to json and patch

### DIFF
--- a/neutronics_material_maker/material_maker_classes.py
+++ b/neutronics_material_maker/material_maker_classes.py
@@ -118,7 +118,7 @@ class Material:
         :return: a neutronics_material_maker.Material object that has
         isotopes and density based on the input material name and modifiers.
         The Material has can return a openmc_material using the
-        .openmc_material property
+        Material.openmc_material property
         :rtype: neutronics_material_maker.Material
     """
 
@@ -151,7 +151,7 @@ class Material:
         self.element_numbers = None
         self.element_symbols = None
 
-        self.populate_from_dictionary()
+        self._populate_from_inbuilt_dictionary()
 
  
 
@@ -182,8 +182,6 @@ class Material:
         self.make_material()
 
 
-
-
     @property
     def material_name(self):
         return self._material_name
@@ -192,7 +190,7 @@ class Material:
     def material_name(self, value):
         if value is not None:
             if type(value) is not str:
-                raise ValueError("material_name must be a string")
+                raise ValueError("material_name must be a string", value)
         self._material_name = value
 
     @property
@@ -203,7 +201,7 @@ class Material:
     def material_tag(self, value):
         if value is not None:
             if type(value) is not str:
-                raise ValueError("material_tag must be a string")
+                raise ValueError("material_tag must be a string", value)
         self._material_tag = value
 
     @property
@@ -221,7 +219,6 @@ class Material:
             raise ValueError("packing_fraction must be less than 1.")
         self._packing_fraction = value
 
-
     @property
     def elements(self):
         return self._elements
@@ -232,7 +229,6 @@ class Material:
             self._elements = value
         else:
             raise ValueError("Elements must be dictionaries e.g. {'Li':0.07, 'Si': 0.93}")
-
 
     @property
     def isotopes(self):
@@ -245,7 +241,6 @@ class Material:
         else:
             raise ValueError("Isotopes must be dictionaries e.g. {'Li6':0.07, 'Li7': 0.93}")
 
-
     @property
     def density_equation(self):
         return self._density_equation
@@ -256,7 +251,6 @@ class Material:
             if type(value) is not str:
                 raise ValueError("density_equation should be a string")
         self._density_equation = value
-
 
     @property
     def density_unit(self):
@@ -269,7 +263,6 @@ class Material:
         else:
             raise ValueError("only 'g/cm3', 'g/cc', 'kg/m3', 'atom/b-cm', 'atom/cm3' are supported for the density_units")
 
-
     @property
     def percent_type(self):
         return self._percent_type
@@ -280,7 +273,6 @@ class Material:
             self._percent_type = value
         else:
             raise ValueError("only 'ao' and 'wo' are supported for the percent_type")
-
 
     @property
     def enrichment_type(self):
@@ -293,8 +285,6 @@ class Material:
                 raise ValueError("only 'ao' and 'wo' are supported for the enrichment_type")
         self._enrichment_type = value
 
-
-
     @property
     def atoms_per_unit_cell(self):
         return self._atoms_per_unit_cell
@@ -305,8 +295,6 @@ class Material:
             if value < 0.:
                 raise ValueError("atoms_per_unit_cell must be greater than 0")
         self._atoms_per_unit_cell = value
-
-
 
     @property
     def volume_of_unit_cell_cm3(self):
@@ -404,7 +392,12 @@ class Material:
         self._reference = value
 
 
-    def populate_from_dictionary(self):
+    def _populate_from_inbuilt_dictionary(self):
+        """This runs on initilisation and if attributes of the Material object are not specified (left as None)
+        then the internal material dictionary is checked to see if defaults are pressent for the particular material.
+        If the attributed has defaults that are present in the internal dictionary then these are used to populated
+        the attributes of the Material object when present.
+        """
 
         if self.temperature_in_C is None and "temperature_in_C" in material_dict[self.material_name].keys():
             self.temperature_in_C = material_dict[self.material_name]["temperature_in_C"]
@@ -550,7 +543,6 @@ class Material:
 
         self.add_density()
 
-
     def get_atoms_in_crystal(self):
 
         tokens = [a for a in re.split(r"([A-Z][a-z]*)", self.chemical_equation) if a]
@@ -569,7 +561,6 @@ class Material:
                     list_of_fractions.append(1)
         self.list_of_fractions = list_of_fractions
         return sum(list_of_fractions)
-
 
     def to_json(self):
 
@@ -632,7 +623,7 @@ class MultiMaterial():
 
 
 
-    def __init__(self, material_tag, materials=[], fracs=[],
+    def __init__(self, material_tag=None, materials=[], fracs=[],
                  percent_type='vo', packing_fraction=1.0):
         self.material_tag = material_tag
         self.materials = materials
@@ -676,7 +667,7 @@ class MultiMaterial():
                 raise ValueError("only openmc.Material or neutronics_material_maker.Materials are accepted. Not", type(material))
 
 
-        openmc_material = openmc.Material.mix_materials(name = self.material_tag,
+        openmc_material = openmc.Material.mix_materials(#name = self.material_tag,
                                                         materials = openmc_material_objects,
                                                         fracs = self.fracs,
                                                         percent_type = self.percent_type)

--- a/neutronics_material_maker/material_maker_classes.py
+++ b/neutronics_material_maker/material_maker_classes.py
@@ -593,9 +593,7 @@ class Material:
                             'reference':self.reference,
         }
 
-        return json.dumps(self, default=lambda o: jsonified_object, 
-            sort_keys=True, indent=4)
-
+        return jsonified_object
 
 
 
@@ -721,5 +719,4 @@ class MultiMaterial():
                             'packing_fraction':self.packing_fraction,
         }
 
-        return json.dumps(self, default=lambda o: jsonified_object, 
-            sort_keys=True, indent=4)
+        return jsonified_object

--- a/neutronics_material_maker/material_maker_classes.py
+++ b/neutronics_material_maker/material_maker_classes.py
@@ -122,24 +122,24 @@ class Material:
         :rtype: neutronics_material_maker.Material
     """
 
-        self._material_name = material_name
-        self._material_tag = material_tag
-        self._temperature_in_C = temperature_in_C
-        self._temperature_in_K = temperature_in_K
-        self._pressure_in_Pa = pressure_in_Pa
-        self._packing_fraction = packing_fraction
-        self._elements = elements
-        self._isotopes = isotopes
-        self._density = density
-        self._density_equation = density_equation
-        self._atoms_per_unit_cell = atoms_per_unit_cell
-        self._volume_of_unit_cell_cm3 = volume_of_unit_cell_cm3
-        self._density_unit = density_unit
-        self._percent_type = percent_type
-        self._enrichment = enrichment
-        self._enrichment_target = enrichment_target
-        self._enrichment_type = enrichment_type
-        self._reference = reference
+        self.material_name = material_name
+        self.material_tag = material_tag
+        self.temperature_in_C = temperature_in_C
+        self.temperature_in_K = temperature_in_K
+        self.pressure_in_Pa = pressure_in_Pa
+        self.packing_fraction = packing_fraction
+        self.elements = elements
+        self.isotopes = isotopes
+        self.density = density
+        self.density_equation = density_equation
+        self.atoms_per_unit_cell = atoms_per_unit_cell
+        self.volume_of_unit_cell_cm3 = volume_of_unit_cell_cm3
+        self.density_unit = density_unit
+        self.percent_type = percent_type
+        self.enrichment = enrichment
+        self.enrichment_target = enrichment_target
+        self.enrichment_type = enrichment_type
+        self.reference = reference
 
         # derived values
         self.enrichment_element = None
@@ -190,8 +190,9 @@ class Material:
 
     @material_name.setter
     def material_name(self, value):
-        if type(value) is not str:
-            raise ValueError("Material names must be a string")
+        if value is not None:
+            if type(value) is not str:
+                raise ValueError("material_name must be a string")
         self._material_name = value
 
     @property
@@ -200,8 +201,9 @@ class Material:
 
     @material_tag.setter
     def material_tag(self, value):
-        if type(value) is not str:
-            raise ValueError("Material tags must be a string")
+        if value is not None:
+            if type(value) is not str:
+                raise ValueError("material_tag must be a string")
         self._material_tag = value
 
     @property
@@ -226,7 +228,10 @@ class Material:
 
     @elements.setter
     def elements(self, value):
-        self._elements = value
+        if type(value) is dict or type(value) is str or value is None:
+            self._elements = value
+        else:
+            raise ValueError("Elements must be dictionaries e.g. {'Li':0.07, 'Si': 0.93}")
 
 
     @property
@@ -247,6 +252,9 @@ class Material:
 
     @density_equation.setter
     def density_equation(self, value):
+        if value is not None:
+            if type(value) is not str:
+                raise ValueError("density_equation should be a string")
         self._density_equation = value
 
 
@@ -280,10 +288,10 @@ class Material:
 
     @enrichment_type.setter
     def enrichment_type(self, value):
-        if value in ['ao', 'wo']:
-            self._enrichment_type = value
-        else:
-            raise ValueError("only 'ao' and 'wo' are supported for the enrichment_type")
+        if value is not None:
+            if value not in ['ao', 'wo']:
+                raise ValueError("only 'ao' and 'wo' are supported for the enrichment_type")
+        self._enrichment_type = value
 
 
 
@@ -293,6 +301,9 @@ class Material:
 
     @atoms_per_unit_cell.setter
     def atoms_per_unit_cell(self, value):
+        if value is not None:
+            if value < 0.:
+                raise ValueError("atoms_per_unit_cell must be greater than 0")
         self._atoms_per_unit_cell = value
 
 
@@ -303,6 +314,9 @@ class Material:
 
     @volume_of_unit_cell_cm3.setter
     def volume_of_unit_cell_cm3(self, value):
+        if value is not None:
+            if value < 0.:
+                raise ValueError("volume_of_unit_cell_cm3 must be greater than 0")
         self._volume_of_unit_cell_cm3 = value
 
 
@@ -312,8 +326,9 @@ class Material:
 
     @temperature_in_K.setter
     def temperature_in_K(self, value):
-        if value < 0.:
-            raise ValueError("temperature_in_K must be greater than 0")
+        if value is not None:
+            if value < 0.:
+                raise ValueError("temperature_in_K must be greater than 0")
         self._temperature_in_K = value
 
 
@@ -323,8 +338,9 @@ class Material:
 
     @temperature_in_C.setter
     def temperature_in_C(self, value):
-        if value < -273.15:
-            raise ValueError("temperature_in_C must be greater than -273.15")
+        if value is not None:
+            if value < -273.15:
+                raise ValueError("temperature_in_C must be greater than -273.15")
         self._temperature_in_C = value
 
 
@@ -334,10 +350,10 @@ class Material:
 
     @density.setter
     def density(self, value):
-        if value > 0:
-            self._density = value
-        else:
-            raise ValueError("Density have been incorrectly set, density should be above 0")
+        if value is not None:        
+            if value < 0:
+                raise ValueError("Density have been incorrectly set, density should be above 0")
+        self._density = value
 
 
     @property
@@ -346,12 +362,10 @@ class Material:
 
     @enrichment.setter
     def enrichment(self, value):
-        if value is None:
-            self._enrichment = value
-        elif value < 0 or value > 100:
-            raise ValueError("Enrichment must be between 0 and 100")
-        else:
-            self._enrichment = value
+        if value is not None:
+            if value < 0 or value > 100:
+                raise ValueError("Enrichment must be between 0 and 100")
+        self._enrichment = value
 
 
     @property
@@ -360,8 +374,9 @@ class Material:
 
     @enrichment_target.setter
     def enrichment_target(self, value):
-        if value not in openmc.data.NATURAL_ABUNDANCE.keys():
-            raise ValueError("enrichment_target must be a naturally occuring isotope from this list", openmc.data.NATURAL_ABUNDANCE.keys())
+        if value is not None:
+            if value not in openmc.data.NATURAL_ABUNDANCE.keys():
+                raise ValueError("enrichment_target must be a naturally occuring isotope from this list", openmc.data.NATURAL_ABUNDANCE.keys())
         self._enrichment_target = value
 
 
@@ -371,8 +386,9 @@ class Material:
 
     @pressure_in_Pa.setter
     def pressure_in_Pa(self, value):
-        if value < 0.:
-            raise ValueError("pressure_in_Pa must be greater than 0")
+        if value is not None:
+            if value < 0.:
+                raise ValueError("pressure_in_Pa must be greater than 0")
         self._pressure_in_Pa = value
 
 
@@ -382,8 +398,9 @@ class Material:
 
     @reference.setter
     def reference(self, value):
-        if not isinstance(value,str):
-            raise ValueError("reference must be a string")
+        if value is not None:
+            if not isinstance(value,str):
+                raise ValueError("reference must be a string")
         self._reference = value
 
 
@@ -556,24 +573,24 @@ class Material:
 
     def to_json(self):
 
-        jsonified_object = {'material_name':self._material_name,
-                            'material_tag':self._material_tag,
-                            'temperature_in_C':self._temperature_in_C,
-                            'temperature_in_K':self._temperature_in_K,
-                            'pressure_in_Pa':self._pressure_in_Pa,
-                            'packing_fraction':self._packing_fraction,
-                            'elements':self._elements,
-                            'isotopes':self._isotopes,
-                            'density':self._density,
-                            'density_equation':self._density_equation,
-                            'atoms_per_unit_cell':self._atoms_per_unit_cell,
-                            'volume_of_unit_cell_cm3':self._volume_of_unit_cell_cm3,
-                            'density_unit':self._density_unit,
-                            'percent_type':self._percent_type,
-                            'enrichment':self._enrichment,
-                            'enrichment_target':self._enrichment_target,
-                            'enrichment_type':self._enrichment_type,
-                            'reference':self._reference,
+        jsonified_object = {'material_name':self.material_name,
+                            'material_tag':self.material_tag,
+                            'temperature_in_C':self.temperature_in_C,
+                            'temperature_in_K':self.temperature_in_K,
+                            'pressure_in_Pa':self.pressure_in_Pa,
+                            'packing_fraction':self.packing_fraction,
+                            'elements':self.elements,
+                            'isotopes':self.isotopes,
+                            'density':self.density,
+                            'density_equation':self.density_equation,
+                            'atoms_per_unit_cell':self.atoms_per_unit_cell,
+                            'volume_of_unit_cell_cm3':self.volume_of_unit_cell_cm3,
+                            'density_unit':self.density_unit,
+                            'percent_type':self.percent_type,
+                            'enrichment':self.enrichment,
+                            'enrichment_target':self.enrichment_target,
+                            'enrichment_type':self.enrichment_type,
+                            'reference':self.reference,
         }
 
         return json.dumps(self, default=lambda o: jsonified_object, 
@@ -678,25 +695,24 @@ class MultiMaterial():
         
         materials_list = []
         for material in self.materials:
-            materials_list.append({'material_name':material._material_name,
-            'material_tag':material._material_tag,
-            'temperature_in_C':material._temperature_in_C,
-            'temperature_in_K':material._temperature_in_K,
-            'pressure_in_Pa':material._pressure_in_Pa,
-            'packing_fraction':material._packing_fraction,
-            'elements':material._elements,
-            'isotopes':material._isotopes,
-            'density':material._density,
-            'density_equation':material._density_equation,
-            'atoms_per_unit_cell':material._atoms_per_unit_cell,
-            'volume_of_unit_cell_cm3':material._volume_of_unit_cell_cm3,
-            'density_unit':material._density_unit,
-            'percent_type':material._percent_type,
-            'enrichment':material._enrichment,
-            'enrichment_target':material._enrichment_target,
-            'enrichment_type':material._enrichment_type,
-            'reference':material._reference,})
-            
+            materials_list.append({'material_name':material.material_name,
+                                    'material_tag':material.material_tag,
+                                    'temperature_in_C':material.temperature_in_C,
+                                    'temperature_in_K':material.temperature_in_K,
+                                    'pressure_in_Pa':material.pressure_in_Pa,
+                                    'packing_fraction':material.packing_fraction,
+                                    'elements':material.elements,
+                                    'isotopes':material.isotopes,
+                                    'density':material.density,
+                                    'density_equation':material.density_equation,
+                                    'atoms_per_unit_cell':material.atoms_per_unit_cell,
+                                    'volume_of_unit_cell_cm3':material.volume_of_unit_cell_cm3,
+                                    'density_unit':material.density_unit,
+                                    'percent_type':material.percent_type,
+                                    'enrichment':material.enrichment,
+                                    'enrichment_target':material.enrichment_target,
+                                    'enrichment_type':material.enrichment_type,
+                                    'reference':material.reference,})
 
         jsonified_object = {'material_tag':self.material_tag,
                             'materials':materials_list,
@@ -704,30 +720,6 @@ class MultiMaterial():
                             'percent_type':self.percent_type,
                             'packing_fraction':self.packing_fraction,
         }
-        # materials=[],
-        # fracs=[],
-        # percent_type='vo',
-        # packing_fraction=1.0
-
-        # jsonified_object = {'material_name':self._material_name,
-        #                     'material_tag':self._material_tag,
-        #                     'temperature_in_C':self._temperature_in_C,
-        #                     'temperature_in_K':self._temperature_in_K,
-        #                     'pressure_in_Pa':self._pressure_in_Pa,
-        #                     'packing_fraction':self._packing_fraction,
-        #                     'elements':self._elements,
-        #                     'isotopes':self._isotopes,
-        #                     'density':self._density,
-        #                     'density_equation':self._density_equation,
-        #                     'atoms_per_unit_cell':self._atoms_per_unit_cell,
-        #                     'volume_of_unit_cell_cm3':self._volume_of_unit_cell_cm3,
-        #                     'density_unit':self._density_unit,
-        #                     'percent_type':self._percent_type,
-        #                     'enrichment':self._enrichment,
-        #                     'enrichment_target':self._enrichment_target,
-        #                     'enrichment_type':self._enrichment_type,
-        #                     'reference':self._reference,
-        # }
 
         return json.dumps(self, default=lambda o: jsonified_object, 
             sort_keys=True, indent=4)

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -250,7 +250,7 @@ class test_object_properties(unittest.TestCase):
 
         def test_json_dump_contains_correct_keys(self):
                 test_material = Material('H2O', temperature_in_C=100, pressure_in_Pa=1e6)
-                test_material_in_json_form = json.loads(test_material.to_json())  
+                test_material_in_json_form = test_material.to_json() 
                 
                 assert 'atoms_per_unit_cell' in test_material_in_json_form.keys()
                 assert 'density' in test_material_in_json_form.keys()
@@ -273,7 +273,7 @@ class test_object_properties(unittest.TestCase):
 
         def test_json_dump_contains_correct_values(self):
                 test_material = Material('H2O', temperature_in_C=100, pressure_in_Pa=1e6)
-                test_material_in_json_form = json.loads(test_material.to_json())  
+                test_material_in_json_form = test_material.to_json()
                 
                 assert test_material_in_json_form['pressure_in_Pa'] == 1e6
                 assert test_material_in_json_form['temperature_in_C'] == 100

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -26,6 +26,7 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
 import pytest
 import unittest
+import json
 
 from neutronics_material_maker import Material
 
@@ -39,8 +40,8 @@ class test_object_properties(unittest.TestCase):
 
                 lithium_lead_elements = 'Li'+str(lithium_fraction) +'Pb'+str(lead_fraction)
                 test_material = Material('lithium-lead',
-                                         elements=lithium_lead_elements,
-                                         temperature_in_C=450)
+                                                elements=lithium_lead_elements,
+                                                temperature_in_C=450)
                 nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
@@ -60,11 +61,11 @@ class test_object_properties(unittest.TestCase):
 
                 lithium_lead_elements = 'Li'+str(lithium_fraction) +'Pb'+str(lead_fraction)
                 test_material = Material('lithium-lead',
-                                         enrichment=enrichment,
-                                         enrichment_target='Li6',
-                                         enrichment_type='ao',
-                                         elements=lithium_lead_elements,
-                                         temperature_in_C=450)
+                                                enrichment=enrichment,
+                                                enrichment_target='Li6',
+                                                enrichment_type='ao',
+                                                elements=lithium_lead_elements,
+                                                temperature_in_C=450)
                 nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
@@ -130,7 +131,7 @@ class test_object_properties(unittest.TestCase):
 
                 test_material = Material(material_name="Li4SiO4")
                 test_material_enriched = Material(material_name="Li4SiO4", enrichment=50., enrichment_target='Li6',
-                                         enrichment_type='ao',)
+                                                enrichment_type='ao',)
                 assert test_material.openmc_material.density > test_material_enriched.openmc_material.density
 
 
@@ -150,8 +151,8 @@ class test_object_properties(unittest.TestCase):
 
                 lithium_lead_elements = 'Li'+str(lithium_fraction) +'Pb'+str(lead_fraction)
                 test_material = Material('lithium-lead',
-                                         elements=lithium_lead_elements,
-                                         temperature_in_C=450)
+                                                elements=lithium_lead_elements,
+                                                temperature_in_C=450)
                 nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
@@ -171,11 +172,11 @@ class test_object_properties(unittest.TestCase):
 
                 lithium_lead_elements = 'Li'+str(lithium_fraction) +'Pb'+str(lead_fraction)
                 test_material = Material('lithium-lead',
-                                         enrichment=enrichment,
-                                         enrichment_target='Li6',
-                                         enrichment_type='ao',
-                                         elements=lithium_lead_elements,
-                                         temperature_in_C=450)
+                                                enrichment=enrichment,
+                                                enrichment_target='Li6',
+                                                enrichment_type='ao',
+                                                elements=lithium_lead_elements,
+                                                temperature_in_C=450)
                 nucs = test_material.openmc_material.nuclides
                 pb_atom_count = 0
                 li_atom_count = 0
@@ -198,6 +199,85 @@ class test_object_properties(unittest.TestCase):
                 assert li6_atom_count == pytest.approx((enrichment/100.) * (lithium_fraction / (lead_fraction+lithium_fraction)), rel=0.01)
                 assert li7_atom_count == pytest.approx(((100.-enrichment)/100) * (lithium_fraction / (lead_fraction+lithium_fraction)), rel=0.01)
 
+        def test_incorrect_settings(self):
+
+                def incorrect_temperature_in_K():
+                        """checks a ValueError is raised when the temperature_in_K is below 0"""
+
+                        Material('H2O', temperature_in_K=-10, pressure_in_Pa=1e6)
+
+                self.assertRaises(
+                ValueError,
+                incorrect_temperature_in_K)
+
+                def incorrect_temperature_in_C():
+                        """checks a ValueError is raised when the temperature_in_C is below absolute zero"""
+
+                        Material('H2O', temperature_in_C=-300, pressure_in_Pa=1e6)
+
+                self.assertRaises(
+                ValueError,
+                incorrect_temperature_in_C)
+
+                def incorrect_enrichment_target():
+                        """checks a ValueError is raised when the enrichment target is not a natural isotope"""
+
+                        Material(material_name="Li4SiO4",
+                                enrichment=50.,
+                                enrichment_target='Li9',
+                                enrichment_type='ao',)
+                
+                self.assertRaises(
+                ValueError,
+                incorrect_enrichment_target)
+
+                def incorrect_reference_type():
+                        """checks a ValueError is raised when the refernces is the wrong type"""
+
+                        Material(material_name="Li4SiO4",
+                                enrichment=50.,
+                                enrichment_target='Li6',
+                                enrichment_type='ao',
+                                reference=1)
+
+                self.assertRaises(
+                ValueError,
+                incorrect_reference_type)
+
+        def test_json_dump_works(self):
+                test_material = Material('H2O', temperature_in_C=100, pressure_in_Pa=1e6)
+                assert type(json.dumps(test_material)) == str
+
+        def test_json_dump_contains_correct_keys(self):
+                test_material = Material('H2O', temperature_in_C=100, pressure_in_Pa=1e6)
+                test_material_in_json_form = json.loads(test_material.to_json())  
+                
+                assert 'atoms_per_unit_cell' in test_material_in_json_form.keys()
+                assert 'density' in test_material_in_json_form.keys()
+                assert 'density_equation' in test_material_in_json_form.keys()
+                assert 'density_unit' in test_material_in_json_form.keys()
+                assert 'elements' in test_material_in_json_form.keys()
+                assert 'enrichment' in test_material_in_json_form.keys()
+                assert 'enrichment_target' in test_material_in_json_form.keys()
+                assert 'enrichment_type' in test_material_in_json_form.keys()
+                assert 'isotopes' in test_material_in_json_form.keys()
+                assert 'material_name' in test_material_in_json_form.keys()
+                assert 'material_tag' in test_material_in_json_form.keys()
+                assert 'packing_fraction' in test_material_in_json_form.keys()
+                assert 'percent_type' in test_material_in_json_form.keys()
+                assert 'pressure_in_Pa' in test_material_in_json_form.keys()
+                assert 'reference' in test_material_in_json_form.keys()
+                assert 'temperature_in_C' in test_material_in_json_form.keys()
+                assert 'temperature_in_K' in test_material_in_json_form.keys()
+                assert 'volume_of_unit_cell_cm3' in test_material_in_json_form.keys()
+
+        def test_json_dump_contains_correct_values(self):
+                test_material = Material('H2O', temperature_in_C=100, pressure_in_Pa=1e6)
+                test_material_in_json_form = json.loads(test_material.to_json())  
+                
+                assert test_material_in_json_form['pressure_in_Pa'] == 1e6
+                assert test_material_in_json_form['temperature_in_C'] == 100
+                assert test_material_in_json_form['material_name'] == 'H2O'
 
 
 if __name__ == '__main__':

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -347,7 +347,7 @@ class test_object_properties(unittest.TestCase):
                                         0.3,
                                         0.7
                                     ])
-                test_material_in_json_form = json.loads(test_material.to_json())  
+                test_material_in_json_form = test_material.to_json()
                 
                 assert 'material_tag' in test_material_in_json_form.keys()
                 assert 'materials' in test_material_in_json_form.keys()
@@ -365,7 +365,7 @@ class test_object_properties(unittest.TestCase):
                                         0.3,
                                         0.7
                                     ])
-                test_material_in_json_form = json.loads(test_material.to_json())  
+                test_material_in_json_form = test_material.to_json()
                 
                 assert test_material_in_json_form['material_tag'] == 'test_material'
                 assert len(test_material_in_json_form['materials']) == 2

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -26,6 +26,7 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
 import pytest
 import unittest
+import json
 
 from neutronics_material_maker import Material, MultiMaterial
 
@@ -323,3 +324,51 @@ class test_object_properties(unittest.TestCase):
                                     percent_type = 'vo')
 
             assert test_material_13.density == test_material_14.density
+
+        def test_json_dump_works(self):
+                test_material = MultiMaterial('test_material',
+                                    materials = [
+                                        Material('tungsten', packing_fraction=0.6),
+                                        Material('eurofer', packing_fraction=0.8)
+                                    ],
+                                    fracs = [
+                                        0.3,
+                                        0.7
+                                    ])
+                assert type(json.dumps(test_material)) == str
+
+        def test_json_dump_contains_correct_keys(self):
+                test_material = MultiMaterial('test_material',
+                                    materials = [
+                                        Material('tungsten', packing_fraction=0.6),
+                                        Material('eurofer', packing_fraction=0.8)
+                                    ],
+                                    fracs = [
+                                        0.3,
+                                        0.7
+                                    ])
+                test_material_in_json_form = json.loads(test_material.to_json())  
+                
+                assert 'material_tag' in test_material_in_json_form.keys()
+                assert 'materials' in test_material_in_json_form.keys()
+                assert 'fracs' in test_material_in_json_form.keys()
+                assert 'percent_type' in test_material_in_json_form.keys()
+                assert 'packing_fraction' in test_material_in_json_form.keys()
+
+        def test_json_dump_contains_correct_values(self):
+                test_material = MultiMaterial('test_material',
+                                    materials = [
+                                        Material('tungsten', packing_fraction=0.6),
+                                        Material('eurofer', packing_fraction=0.8)
+                                    ],
+                                    fracs = [
+                                        0.3,
+                                        0.7
+                                    ])
+                test_material_in_json_form = json.loads(test_material.to_json())  
+                
+                assert test_material_in_json_form['material_tag'] == 'test_material'
+                assert len(test_material_in_json_form['materials']) == 2
+                assert test_material_in_json_form['fracs'] == [0.3, 0.7]
+                assert test_material_in_json_form['percent_type'] == 'vo'
+                assert test_material_in_json_form['packing_fraction'] == 1.


### PR DESCRIPTION
This PR adds a to_json method to the MutliMaterial and Material classes, it also overwrites the default JSONEncoder as this was not able to serialize the class.

Making the class serializable allows materials and multimaterials to be exported to a json file which requires the json.dump() to work. Previously this would return a Material is not serializable error but now it returns a dictionary containing the class in dictionary form

```python
from neutronics_material_maker import Material
import json
b = Material('H2O',temperature_in_C=30, pressure_in_Pa=101325)
json.dump(b)
```
A couple of extra checks have also been added to the setters

ToDo
add tests for json dump to check entries are complete and correct
add tests for new validation in setters for temperature_in_K, temperature_in_C, enrichment_target and reference