### PR TITLE
Adding external material loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# build with the following command
+# sudo docker build -t neutronics_material_maker .
+
+FROM ubuntu:18.04
+
+# Updating Ubuntu packages
+RUN apt-get update && yes|apt-get upgrade
+
+# Adding wget and bzip2
+RUN apt-get install -y wget bzip2
+
+# Anaconda installing
+RUN wget https://repo.continuum.io/archive/Anaconda3-2020.02-Linux-x86_64.sh
+
+RUN bash Anaconda3-2020.02-Linux-x86_64.sh -b
+
+RUN rm Anaconda3-2020.02-Linux-x86_64.sh
+
+# Set path to conda
+ENV PATH /root/anaconda3/bin:$PATH
+
+# install openmc from conda involves less sets compared to compiling it from source
+RUN conda install -c conda-forge openmc
+
+
+# install endf nuclear data
+
+# clone the openmc nuclear data repository
+RUN apt-get update
+RUN apt-get install -y git
+RUN git clone https://github.com/openmc-dev/data.git
+
+# run script that converts ACE data to hdf5 data
+RUN python data/convert_nndc71.py --cleanup
+
+ENV OPENMC_CROSS_SECTIONS=/nndc-b7.1-hdf5/cross_sections.xml
+
+RUN pip install-neutronics-material-maker

--- a/neutronics_material_maker/__init__.py
+++ b/neutronics_material_maker/__init__.py
@@ -1,1 +1,4 @@
-from .material_maker_classes import Material, MultiMaterial
+from .material import Material
+from .material import AddMaterialFromDir
+from .material import AddMaterialFromFile
+from .mutlimaterial import MultiMaterial

--- a/neutronics_material_maker/__init__.py
+++ b/neutronics_material_maker/__init__.py
@@ -1,4 +1,5 @@
 from .material import Material
 from .material import AddMaterialFromDir
 from .material import AddMaterialFromFile
+from .material import AvailableMaterials
 from .mutlimaterial import MultiMaterial

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -1,34 +1,53 @@
 #!/usr/bin/env python3
 
-__author__ = "Jonathan Shimwell"
+__author__ = "neutronics material maker development team"
 
-import re
 import json
+import re
 from json import JSONEncoder
-
+import os
+import json
+from pathlib import Path
 
 import openmc
 from CoolProp.CoolProp import PropsSI
 
-from .all_materials import material_dict
-
 atomic_mass_unit_in_g = 1.660539040e-24
-
 
 """ monkey-patches json module so that the custom to_json
 method is used which allows Materials to be json dumped
 """
 
-
 def _default(self, obj):
     return getattr(obj.__class__, "to_json", _default.default)(obj)
-
 
 _default.default = JSONEncoder.default
 JSONEncoder.default = _default
 
 
-class Material:
+def AddMaterialFromDir(directory=None):
+        """Add materials to the internal library from a directory of json files"""
+        for filename in Path(directory).glob("*.json"):
+            with open(filename, "r") as f:
+                new_data = json.load(f)
+                material_dict.update(new_data)
+
+        print("Added materials to library", sorted(list(material_dict.keys())))
+
+
+def AddMaterialFromFile(filename=None):
+        """Add materials to the internal library from a json file"""
+        with open(filename, "r") as f:
+            new_data = json.load(f)
+            material_dict.update(new_data)
+        print("Added materials to library", sorted(list(material_dict.keys())))
+
+# loads the internal material library of materials
+material_dict = {}
+AddMaterialFromDir(Path(__file__).parent / "data")
+
+
+class Material():
     def __init__(
         self,
         material_name,
@@ -684,150 +703,6 @@ class Material:
             "enrichment_target": self.enrichment_target,
             "enrichment_type": self.enrichment_type,
             "reference": self.reference,
-        }
-
-        return jsonified_object
-
-
-class MultiMaterial:
-    """Produces a mixed material from several indivdual materials.
-        This class extends the existing openmc.Material.mix_materials
-        to perform this mixing on neutronics_materail_maker.Materials
-        and packing fractions (inverse of void fraction) to be applied
-
-       :param material_tag: this is a string that is assigned to the
-        multimaterial as an identifier. This is used by neutronics
-        codes that need to access materials via a unique identifier
-       :type material_tag: string
-       :param materials: a list of neutronics_material_maker.Materials
-        or openmc.Materials that are to be mixed
-       :type materials: list of Material objects
-       :param fracs: a list of fractions that represent the amount of
-        each material to mix
-       :type fracs: a list of floats
-       :param percent_type: Type of frac percentage, must be one of
-        'ao', 'wo', or 'vo', to signify atom percent (molar percent),
-        weight percent, or volume percent, optional. Defaults to 'vo'
-       :type percent_type: string
-       :param packing_fraction: this value is mutliplier by the density
-        which allows packing_fraction to be taken into account for materials
-        involving an amount of void. Recall that packing_fraction is equal
-        to 1/void fraction
-       :type packing_fraction: float
-
-        :return: a neutronics_material_maker.MultiMaterial object that has
-        isotopes and density based on the input materials and modifiers.
-        The MultiMaterial has can return a openmc_material using the
-        .openmc_material property
-        :rtype: neutronics_material_maker.MultiMaterial
-    """
-
-    def __init__(
-        self,
-        material_tag=None,
-        materials=[],
-        fracs=[],
-        percent_type="vo",
-        packing_fraction=1.0,
-    ):
-        self.material_tag = material_tag
-        self.materials = materials
-        self.fracs = fracs
-        self.percent_type = percent_type
-        self.packing_fraction = packing_fraction
-        self.openmc_material = None
-
-        self.make_material()
-
-    @property
-    def packing_fraction(self):
-        return self._packing_fraction
-
-    @packing_fraction.setter
-    def packing_fraction(self, value):
-        value = float(value)
-        if not isinstance(value, float):
-            raise ValueError("packing_fraction must be a float")
-        if value < 0.0:
-            raise ValueError("packing_fraction must be greater than 0")
-        if value > 1.0:
-            raise ValueError("packing_fraction must be less than 1.")
-        self._packing_fraction = value
-
-    def make_material(self):
-
-        if len(self.fracs) != len(self.materials):
-            raise ValueError(
-                "There must be equal numbers of fracs and materials")
-
-        if sum(self.fracs) != 1.0:
-            print(
-                "warning sum of MutliMaterials do not sum to 1.",
-                self.fracs,
-                " = ",
-                sum(self.fracs),
-            )
-
-        openmc_material_objects = []
-        for material in self.materials:
-            if isinstance(material, openmc.Material):
-                openmc_material_objects.append(material)
-            elif isinstance(material, Material):
-                openmc_material_objects.append(material.openmc_material)
-            else:
-                raise ValueError(
-                    "only openmc.Material or neutronics_material_maker.Materials are accepted. Not",
-                    type(material),
-                )
-
-        openmc_material = openmc.Material.mix_materials(  # name = self.material_tag,
-            materials=openmc_material_objects,
-            fracs=self.fracs,
-            percent_type=self.percent_type,
-        )
-
-        # this modifies the density by the packing fraction of the material
-        if self.packing_fraction != 1.0:
-            density_in_g_per_cm3 = openmc_material.get_mass_density()
-
-            openmc_material.set_density(
-                "g/cm3", density_in_g_per_cm3 * self.packing_fraction
-            )
-
-        self.openmc_material = openmc_material
-
-    def to_json(self):
-
-        materials_list = []
-        for material in self.materials:
-            materials_list.append(
-                {
-                    "material_name": material.material_name,
-                    "material_tag": material.material_tag,
-                    "temperature_in_C": material.temperature_in_C,
-                    "temperature_in_K": material.temperature_in_K,
-                    "pressure_in_Pa": material.pressure_in_Pa,
-                    "packing_fraction": material.packing_fraction,
-                    "elements": material.elements,
-                    "isotopes": material.isotopes,
-                    "density": material.density,
-                    "density_equation": material.density_equation,
-                    "atoms_per_unit_cell": material.atoms_per_unit_cell,
-                    "volume_of_unit_cell_cm3": material.volume_of_unit_cell_cm3,
-                    "density_unit": material.density_unit,
-                    "percent_type": material.percent_type,
-                    "enrichment": material.enrichment,
-                    "enrichment_target": material.enrichment_target,
-                    "enrichment_type": material.enrichment_type,
-                    "reference": material.reference,
-                })
-
-        jsonified_object = {
-            "material_tag": self.material_tag,
-            "materials": materials_list,
-            "fracs": self.fracs,
-            "percent_type": self.percent_type,
-            "packing_fraction": self.packing_fraction,
         }
 
         return jsonified_object

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -21,35 +21,37 @@ def _default(self, obj):
     """
     return getattr(obj.__class__, "to_json", _default.default)(obj)
 
+
 _default.default = JSONEncoder.default
 JSONEncoder.default = _default
 
 
 def AddMaterialFromDir(directory=None):
-        """Add materials to the internal library from a directory of json files"""
-        for filename in Path(directory).glob("*.json"):
-            with open(filename, "r") as f:
-                new_data = json.load(f)
-                material_dict.update(new_data)
-
-        print("Added materials to library", sorted(list(material_dict.keys())))
-
-
-def AddMaterialFromFile(filename=None):
-        """Add materials to the internal library from a json file"""
+    """Add materials to the internal library from a directory of json files"""
+    for filename in Path(directory).glob("*.json"):
         with open(filename, "r") as f:
             new_data = json.load(f)
             material_dict.update(new_data)
-        print("Added materials to library", sorted(list(material_dict.keys())))
-    
+
+    print("Added materials to library", sorted(list(material_dict.keys())))
+
+
+def AddMaterialFromFile(filename=None):
+    """Add materials to the internal library from a json file"""
+    with open(filename, "r") as f:
+        new_data = json.load(f)
+        material_dict.update(new_data)
+    print("Added materials to library", sorted(list(material_dict.keys())))
+
+
 def AvailableMaterials():
     """Returns a dictionary of avaialbe materials"""
     return material_dict
 
+
 # loads the internal material library of materials
 material_dict = {}
 AddMaterialFromDir(Path(__file__).parent / "data")
-
 
 
 class Material():

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -14,11 +14,11 @@ from CoolProp.CoolProp import PropsSI
 
 atomic_mass_unit_in_g = 1.660539040e-24
 
-""" monkey-patches json module so that the custom to_json
-method is used which allows Materials to be json dumped
-"""
 
 def _default(self, obj):
+    """ monkey-patches json module so that the custom to_json
+    method is used which allows Materials to be json dumped
+    """
     return getattr(obj.__class__, "to_json", _default.default)(obj)
 
 _default.default = JSONEncoder.default
@@ -41,10 +41,15 @@ def AddMaterialFromFile(filename=None):
             new_data = json.load(f)
             material_dict.update(new_data)
         print("Added materials to library", sorted(list(material_dict.keys())))
+    
+def AvailableMaterials():
+    """Returns a dictionary of avaialbe materials"""
+    return material_dict
 
 # loads the internal material library of materials
 material_dict = {}
 AddMaterialFromDir(Path(__file__).parent / "data")
+
 
 
 class Material():
@@ -551,6 +556,7 @@ class Material():
             self.reference = material_dict[self.material_name]["reference"]
 
     def add_elements(self):
+        """Adds elements from a dictionary or chemical formula to the Material"""
 
         if isinstance(self.elements, dict):
 
@@ -590,6 +596,7 @@ class Material():
             )
 
     def add_isotopes(self):
+        """Adds isotopes from a dictionary or chemical formula to the Material"""
 
         for isotope_symbol, isotope_number in zip(
             self.isotopes.keys(), self.isotopes.values()
@@ -600,6 +607,7 @@ class Material():
             )
 
     def add_density(self):
+        """Calculates the density of the Material"""
 
         if isinstance(self.density, float):
             pass
@@ -663,6 +671,7 @@ class Material():
         self.add_density()
 
     def get_atoms_in_crystal(self):
+        """Finds the number of atoms in the crystal lactic"""
 
         tokens = [
             a for a in re.split(

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -17,8 +17,10 @@ atomic_mass_unit_in_g = 1.660539040e-24
 method is used which allows Materials to be json dumped
 """
 
+
 def _default(self, obj):
     return getattr(obj.__class__, "to_json", _default.default)(obj)
+
 
 _default.default = JSONEncoder.default
 JSONEncoder.default = _default

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+__author__ = "neutronics material maker development team"
+
+import json
+import re
+from json import JSONEncoder
+
+import openmc
+from CoolProp.CoolProp import PropsSI
+import neutronics_material_maker
+
+atomic_mass_unit_in_g = 1.660539040e-24
+
+
+""" monkey-patches json module so that the custom to_json
+method is used which allows Materials to be json dumped
+"""
+
+def _default(self, obj):
+    return getattr(obj.__class__, "to_json", _default.default)(obj)
+
+_default.default = JSONEncoder.default
+JSONEncoder.default = _default
+
+
+class MultiMaterial:
+    """Produces a mixed material from several indivdual materials.
+        This class extends the existing openmc.Material.mix_materials
+        to perform this mixing on neutronics_materail_maker.Materials
+        and packing fractions (inverse of void fraction) to be applied
+
+       :param material_tag: this is a string that is assigned to the
+        multimaterial as an identifier. This is used by neutronics
+        codes that need to access materials via a unique identifier
+       :type material_tag: string
+       :param materials: a list of neutronics_material_maker.Materials
+        or openmc.Materials that are to be mixed
+       :type materials: list of Material objects
+       :param fracs: a list of fractions that represent the amount of
+        each material to mix
+       :type fracs: a list of floats
+       :param percent_type: Type of frac percentage, must be one of
+        'ao', 'wo', or 'vo', to signify atom percent (molar percent),
+        weight percent, or volume percent, optional. Defaults to 'vo'
+       :type percent_type: string
+       :param packing_fraction: this value is mutliplier by the density
+        which allows packing_fraction to be taken into account for materials
+        involving an amount of void. Recall that packing_fraction is equal
+        to 1/void fraction
+       :type packing_fraction: float
+
+        :return: a neutronics_material_maker.MultiMaterial object that has
+        isotopes and density based on the input materials and modifiers.
+        The MultiMaterial has can return a openmc_material using the
+        .openmc_material property
+        :rtype: neutronics_material_maker.MultiMaterial
+    """
+
+    def __init__(
+        self,
+        material_tag=None,
+        materials=[],
+        fracs=[],
+        percent_type="vo",
+        packing_fraction=1.0,
+    ):
+        self.material_tag = material_tag
+        self.materials = materials
+        self.fracs = fracs
+        self.percent_type = percent_type
+        self.packing_fraction = packing_fraction
+        self.openmc_material = None
+
+        self.make_material()
+
+    @property
+    def packing_fraction(self):
+        return self._packing_fraction
+
+    @packing_fraction.setter
+    def packing_fraction(self, value):
+        value = float(value)
+        if not isinstance(value, float):
+            raise ValueError("packing_fraction must be a float")
+        if value < 0.0:
+            raise ValueError("packing_fraction must be greater than 0")
+        if value > 1.0:
+            raise ValueError("packing_fraction must be less than 1.")
+        self._packing_fraction = value
+
+    def make_material(self):
+
+        if len(self.fracs) != len(self.materials):
+            raise ValueError(
+                "There must be equal numbers of fracs and materials")
+
+        if sum(self.fracs) != 1.0:
+            print(
+                "warning sum of MutliMaterials do not sum to 1.",
+                self.fracs,
+                " = ",
+                sum(self.fracs),
+            )
+
+        openmc_material_objects = []
+        for material in self.materials:
+            if isinstance(material, openmc.Material):
+                openmc_material_objects.append(material)
+            elif isinstance(material, neutronics_material_maker.Material):
+                openmc_material_objects.append(material.openmc_material)
+            else:
+                raise ValueError(
+                    "only openmc.Material or neutronics_material_maker.Materials are accepted. Not",
+                    type(material),
+                )
+
+        openmc_material = openmc.Material.mix_materials(  # name = self.material_tag,
+            materials=openmc_material_objects,
+            fracs=self.fracs,
+            percent_type=self.percent_type,
+        )
+
+        # this modifies the density by the packing fraction of the material
+        if self.packing_fraction != 1.0:
+            density_in_g_per_cm3 = openmc_material.get_mass_density()
+
+            openmc_material.set_density(
+                "g/cm3", density_in_g_per_cm3 * self.packing_fraction
+            )
+
+        self.openmc_material = openmc_material
+
+    def to_json(self):
+
+        materials_list = []
+        for material in self.materials:
+            materials_list.append(
+                {
+                    "material_name": material.material_name,
+                    "material_tag": material.material_tag,
+                    "temperature_in_C": material.temperature_in_C,
+                    "temperature_in_K": material.temperature_in_K,
+                    "pressure_in_Pa": material.pressure_in_Pa,
+                    "packing_fraction": material.packing_fraction,
+                    "elements": material.elements,
+                    "isotopes": material.isotopes,
+                    "density": material.density,
+                    "density_equation": material.density_equation,
+                    "atoms_per_unit_cell": material.atoms_per_unit_cell,
+                    "volume_of_unit_cell_cm3": material.volume_of_unit_cell_cm3,
+                    "density_unit": material.density_unit,
+                    "percent_type": material.percent_type,
+                    "enrichment": material.enrichment,
+                    "enrichment_target": material.enrichment_target,
+                    "enrichment_type": material.enrichment_type,
+                    "reference": material.reference,
+                })
+
+        jsonified_object = {
+            "material_tag": self.material_tag,
+            "materials": materials_list,
+            "fracs": self.fracs,
+            "percent_type": self.percent_type,
+            "packing_fraction": self.packing_fraction,
+        }
+
+        return jsonified_object

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1235.41",
+    version="0.1235.42",
     summary="Package for making material cards for OpenMC",
     author="Jonathan Shimwell",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -37,11 +37,11 @@ class test_object_properties(unittest.TestCase):
 
     def test_adding_one_material_AddMaterialFromFile(self):
         test_material_1 = {"WC2": {"elements": "WC",
-                                    "density": 18.0,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    }
-                            }
+                                   "density": 18.0,
+                                   "density_unit": "g/cm3",
+                                   "percent_type": "ao"
+                                   }
+                           }
 
         with open('extra_material_1.json', 'w') as outfile:
             json.dump(test_material_1, outfile)
@@ -55,16 +55,16 @@ class test_object_properties(unittest.TestCase):
 
     def test_adding_two_material_AddMaterialFromFile(self):
         test_material_1 = {"WC3": {"elements": "WC",
-                                    "density": 18.0,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    },
-                            "WB2": {"elements": "WB",
-                                    "density": 15.3,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    }
-                            }
+                                   "density": 18.0,
+                                   "density_unit": "g/cm3",
+                                   "percent_type": "ao"
+                                   },
+                           "WB2": {"elements": "WB",
+                                   "density": 15.3,
+                                   "density_unit": "g/cm3",
+                                   "percent_type": "ao"
+                                   }
+                           }
 
         with open('extra_material_1.json', 'w') as outfile:
             json.dump(test_material_1, outfile)
@@ -79,11 +79,11 @@ class test_object_properties(unittest.TestCase):
 
     def test_replacing_material_using_AddMaterialFromFile(self):
         test_material_1 = {"Li4SiO4": {"elements": "WC",
-                                    "density": 18.0,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    }
-                            }
+                                       "density": 18.0,
+                                       "density_unit": "g/cm3",
+                                       "percent_type": "ao"
+                                       }
+                           }
 
         with open('extra_material_1.json', 'w') as outfile:
             json.dump(test_material_1, outfile)
@@ -99,23 +99,23 @@ class test_object_properties(unittest.TestCase):
         os.system('mkdir new_materials')
 
         test_material_1 = {"Li4SiO42": {"elements": "WC",
-                                    "density": 18.0,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    }
-                            }
+                                        "density": 18.0,
+                                        "density_unit": "g/cm3",
+                                        "percent_type": "ao"
+                                        }
+                           }
 
-        with open(os.path.join('new_materials','extra_material_1.json'), 'w') as outfile:
+        with open(os.path.join('new_materials', 'extra_material_1.json'), 'w') as outfile:
             json.dump(test_material_1, outfile)
 
         test_material_2 = {"Li4SiO43": {"elements": "WC",
-                                    "density": 18.0,
-                                    "density_unit": "g/cm3",
-                                    "percent_type": "ao"
-                                    }
-                            }
+                                        "density": 18.0,
+                                        "density_unit": "g/cm3",
+                                        "percent_type": "ao"
+                                        }
+                           }
 
-        with open(os.path.join('new_materials','extra_material_2.json'), 'w') as outfile:
+        with open(os.path.join('new_materials', 'extra_material_2.json'), 'w') as outfile:
             json.dump(test_material_2, outfile)
 
         number_of_materials = len(nmm.AvailableMaterials())

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -24,14 +24,107 @@ IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 """
 
-import pytest
-import unittest
 import json
+import os
+import unittest
 
-from neutronics_material_maker import Material
+import pytest
+
+import neutronics_material_maker as nmm
 
 
 class test_object_properties(unittest.TestCase):
+
+    def test_adding_one_material_AddMaterialFromFile(self):
+        test_material_1 = {"WC2": {"elements": "WC",
+                                    "density": 18.0,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    }
+                            }
+
+        with open('extra_material_1.json', 'w') as outfile:
+            json.dump(test_material_1, outfile)
+
+        number_of_materials = len(nmm.AvailableMaterials())
+        nmm.AddMaterialFromFile('extra_material_1.json')
+
+        assert number_of_materials + 1 == len(nmm.AvailableMaterials())
+        assert 'WC2' in nmm.AvailableMaterials().keys()
+        os.system('rm extra_material_1.json')
+
+    def test_adding_two_material_AddMaterialFromFile(self):
+        test_material_1 = {"WC3": {"elements": "WC",
+                                    "density": 18.0,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    },
+                            "WB2": {"elements": "WB",
+                                    "density": 15.3,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    }
+                            }
+
+        with open('extra_material_1.json', 'w') as outfile:
+            json.dump(test_material_1, outfile)
+
+        number_of_materials = len(nmm.AvailableMaterials())
+        nmm.AddMaterialFromFile('extra_material_1.json')
+
+        assert number_of_materials + 2 == len(nmm.AvailableMaterials())
+        assert 'WC3' in nmm.AvailableMaterials().keys()
+        assert 'WB2' in nmm.AvailableMaterials().keys()
+        os.system('rm extra_material_1.json')
+
+    def test_replacing_material_using_AddMaterialFromFile(self):
+        test_material_1 = {"Li4SiO4": {"elements": "WC",
+                                    "density": 18.0,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    }
+                            }
+
+        with open('extra_material_1.json', 'w') as outfile:
+            json.dump(test_material_1, outfile)
+
+        number_of_materials = len(nmm.AvailableMaterials())
+        nmm.AddMaterialFromFile('extra_material_1.json')
+
+        assert number_of_materials == len(nmm.AvailableMaterials())
+        assert 'Li4SiO4' in nmm.AvailableMaterials().keys()
+        os.system('rm extra_material_1.json')
+
+    def test_AddMaterialFromDir(self):
+        os.system('mkdir new_materials')
+
+        test_material_1 = {"Li4SiO42": {"elements": "WC",
+                                    "density": 18.0,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    }
+                            }
+
+        with open(os.path.join('new_materials','extra_material_1.json'), 'w') as outfile:
+            json.dump(test_material_1, outfile)
+
+        test_material_2 = {"Li4SiO43": {"elements": "WC",
+                                    "density": 18.0,
+                                    "density_unit": "g/cm3",
+                                    "percent_type": "ao"
+                                    }
+                            }
+
+        with open(os.path.join('new_materials','extra_material_2.json'), 'w') as outfile:
+            json.dump(test_material_2, outfile)
+
+        number_of_materials = len(nmm.AvailableMaterials())
+        nmm.AddMaterialFromDir('new_materials')
+
+        assert number_of_materials + 2 == len(nmm.AvailableMaterials())
+        assert 'Li4SiO42' in nmm.AvailableMaterials().keys()
+        assert 'Li4SiO43' in nmm.AvailableMaterials().keys()
+
     def test_material_creation_from_chemical_formula(self):
 
         lead_fraction = 3
@@ -39,7 +132,7 @@ class test_object_properties(unittest.TestCase):
 
         lithium_lead_elements = "Li" + \
             str(lithium_fraction) + "Pb" + str(lead_fraction)
-        test_material = Material(
+        test_material = nmm.Material(
             "lithium-lead",
             elements=lithium_lead_elements,
             temperature_in_C=450)
@@ -62,7 +155,7 @@ class test_object_properties(unittest.TestCase):
 
         lithium_lead_elements = "Li" + \
             str(lithium_fraction) + "Pb" + str(lead_fraction)
-        test_material = Material(
+        test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
             enrichment_target="Li6",
@@ -100,47 +193,47 @@ class test_object_properties(unittest.TestCase):
         # these tests fail because the density value is too far away from calculated value
         # however, this could be becuase the density values are rounded to 2 dp
 
-        test_material = Material(material_name="Li4SiO4")
+        test_material = nmm.Material(material_name="Li4SiO4")
         assert test_material.openmc_material.density == pytest.approx(
             2.32, rel=0.01)
 
-        test_material = Material(material_name="Li2SiO3")
+        test_material = nmm.Material(material_name="Li2SiO3")
         assert test_material.openmc_material.density == pytest.approx(
             2.44, rel=0.01)
 
-        test_material = Material(material_name="Li2ZrO3")
+        test_material = nmm.Material(material_name="Li2ZrO3")
         assert test_material.openmc_material.density == pytest.approx(
             4.03, rel=0.01)
 
-        test_material = Material(material_name="Li2TiO3")
+        test_material = nmm.Material(material_name="Li2TiO3")
         assert test_material.openmc_material.density == pytest.approx(
             3.34, rel=0.01)
 
-        test_material = Material(material_name="Li8PbO6")
+        test_material = nmm.Material(material_name="Li8PbO6")
         assert test_material.openmc_material.density == pytest.approx(
             4.14, rel=0.01)
 
-        test_material = Material(material_name="Be")
+        test_material = nmm.Material(material_name="Be")
         assert test_material.openmc_material.density == pytest.approx(
             1.88, rel=0.01)
 
-        test_material = Material(material_name="Be12Ti")
+        test_material = nmm.Material(material_name="Be12Ti")
         assert test_material.openmc_material.density == pytest.approx(
             2.28, rel=0.01)
 
-        test_material = Material(material_name="Ba5Pb3")
+        test_material = nmm.Material(material_name="Ba5Pb3")
         assert test_material.openmc_material.density == pytest.approx(
             5.84, rel=0.01)
 
-        test_material = Material(material_name="Nd5Pb4")
+        test_material = nmm.Material(material_name="Nd5Pb4")
         assert test_material.openmc_material.density == pytest.approx(
             8.79, rel=0.01)
 
-        test_material = Material(material_name="Zr5Pb3")
+        test_material = nmm.Material(material_name="Zr5Pb3")
         assert test_material.openmc_material.density == pytest.approx(
             8.23, rel=0.01)
 
-        # test_material = Material(material_name="Zr5Pb4")
+        # test_material = nmm.Material(material_name="Zr5Pb4")
         # assert test_material.openmc_material.density ==
         # pytest.approx(#insert)
 
@@ -148,8 +241,8 @@ class test_object_properties(unittest.TestCase):
 
     def test_density_of_enriched_crystals(self):
 
-        test_material = Material(material_name="Li4SiO4")
-        test_material_enriched = Material(
+        test_material = nmm.Material(material_name="Li4SiO4")
+        test_material_enriched = nmm.Material(
             material_name="Li4SiO4",
             enrichment=50.0,
             enrichment_target="Li6",
@@ -162,8 +255,8 @@ class test_object_properties(unittest.TestCase):
 
     def test_density_of_packed_crystals(self):
 
-        test_material = Material(material_name="Li4SiO4")
-        test_material_packed = Material(
+        test_material = nmm.Material(material_name="Li4SiO4")
+        test_material_packed = nmm.Material(
             material_name="Li4SiO4", packing_fraction=0.35)
         assert (
             test_material.openmc_material.density * 0.35
@@ -177,7 +270,7 @@ class test_object_properties(unittest.TestCase):
 
         lithium_lead_elements = "Li" + \
             str(lithium_fraction) + "Pb" + str(lead_fraction)
-        test_material = Material(
+        test_material = nmm.Material(
             "lithium-lead",
             elements=lithium_lead_elements,
             temperature_in_C=450)
@@ -202,7 +295,7 @@ class test_object_properties(unittest.TestCase):
 
         lithium_lead_elements = "Li" + \
             str(lithium_fraction) + "Pb" + str(lead_fraction)
-        test_material = Material(
+        test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
             enrichment_target="Li6",
@@ -246,21 +339,21 @@ class test_object_properties(unittest.TestCase):
         def incorrect_temperature_in_K():
             """checks a ValueError is raised when the temperature_in_K is below 0"""
 
-            Material("H2O", temperature_in_K=-10, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature_in_K=-10, pressure_in_Pa=1e6)
 
         self.assertRaises(ValueError, incorrect_temperature_in_K)
 
         def incorrect_temperature_in_C():
             """checks a ValueError is raised when the temperature_in_C is below absolute zero"""
 
-            Material("H2O", temperature_in_C=-300, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature_in_C=-300, pressure_in_Pa=1e6)
 
         self.assertRaises(ValueError, incorrect_temperature_in_C)
 
         def incorrect_enrichment_target():
             """checks a ValueError is raised when the enrichment target is not a natural isotope"""
 
-            Material(
+            nmm.Material(
                 material_name="Li4SiO4",
                 enrichment=50.0,
                 enrichment_target="Li9",
@@ -272,7 +365,7 @@ class test_object_properties(unittest.TestCase):
         def incorrect_reference_type():
             """checks a ValueError is raised when the refernces is the wrong type"""
 
-            Material(
+            nmm.Material(
                 material_name="Li4SiO4",
                 enrichment=50.0,
                 enrichment_target="Li6",
@@ -283,14 +376,14 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_reference_type)
 
     def test_json_dump_works(self):
-        test_material = Material(
+        test_material = nmm.Material(
             "H2O",
             temperature_in_C=100,
             pressure_in_Pa=1e6)
         assert isinstance(json.dumps(test_material), str)
 
     def test_json_dump_contains_correct_keys(self):
-        test_material = Material(
+        test_material = nmm.Material(
             "H2O",
             temperature_in_C=100,
             pressure_in_Pa=1e6)
@@ -316,7 +409,7 @@ class test_object_properties(unittest.TestCase):
         assert "volume_of_unit_cell_cm3" in test_material_in_json_form.keys()
 
     def test_json_dump_contains_correct_values(self):
-        test_material = Material(
+        test_material = nmm.Material(
             "H2O",
             temperature_in_C=100,
             pressure_in_Pa=1e6)


### PR DESCRIPTION
This PR adds to new functions that allow users to add additional dictionaries of materials from external files or folders

import neutronics_material_maker as nmm

nmm.AddMaterialFromDir(directory=None)
"""Add materials to the internal library from a directory of json files"""

nmm.AddMaterialFromFile(filename=None)
"""Add materials to the internal library from a json file"""

Additionally users can now check the materials available using nmm.AvailableMaterials

This is useful for adding materials that are not in the internal library