### PR TITLE
Without openmc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,10 @@ release = "1.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.coverage", "sphinx.ext.napoleon"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,10 +38,7 @@ release = "1.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.coverage",
-    "sphinx.ext.napoleon"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.coverage", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -130,11 +127,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc,
-     "NeutronicsMaterialMaker.tex",
-     "NeutronicsMaterialMaker Documentation",
-     "John Billingsley",
-     "manual"),
+    (
+        master_doc,
+        "NeutronicsMaterialMaker.tex",
+        "NeutronicsMaterialMaker Documentation",
+        "John Billingsley",
+        "manual",
+    )
 ]
 
 
@@ -143,11 +142,14 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc,
-     "NeutronicsMaterialMaker",
-     "NeutronicsMaterialMaker Documentation",
-     [author],
-     1)]
+    (
+        master_doc,
+        "NeutronicsMaterialMaker",
+        "NeutronicsMaterialMaker Documentation",
+        [author],
+        1,
+    )
+]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -164,7 +166,7 @@ texinfo_documents = [
         "NeutronicsMaterialMaker",
         "One line description of project.",
         "Miscellaneous",
-    ),
+    )
 ]
 
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -7,10 +7,11 @@ import re
 from json import JSONEncoder
 from pathlib import Path
 
+import warnings
 try:
     import openmc
-except ImportError as err:
-    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+except:
+    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 from CoolProp.CoolProp import PropsSI
 
@@ -243,8 +244,6 @@ class Material:
                     raise ValueError(
                         "pressure_in_Pa is needed for",
                         self.material_name)
-
-        # self.make_openmc_material()
 
     @property
     def openmc_material(self):

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -221,7 +221,8 @@ class Material:
                         "enrichment target and enrichment type are needed to enrich a material"
                     )
 
-            if "temperature_dependant" in material_dict[self.material_name].keys():
+            if "temperature_dependant" in material_dict[self.material_name].keys(
+            ):
                 if temperature_in_K is None and temperature_in_C is None:
                     if self.material_name == "He":
                         raise ValueError(
@@ -245,9 +246,12 @@ class Material:
                     if temperature_in_C is None:
                         self.temperature_in_C = temperature_in_K + 273.15
 
-            if "pressure_dependant" in material_dict[self.material_name].keys():
+            if "pressure_dependant" in material_dict[self.material_name].keys(
+            ):
                 if pressure_in_Pa is None:
-                    raise ValueError("pressure_in_Pa is needed for", self.material_name)
+                    raise ValueError(
+                        "pressure_in_Pa is needed for",
+                        self.material_name)
 
     @property
     def openmc_material(self):
@@ -402,7 +406,8 @@ class Material:
         if value in ["ao", "wo", None]:
             self._percent_type = value
         else:
-            raise ValueError("only 'ao' and 'wo' are supported for the percent_type")
+            raise ValueError(
+                "only 'ao' and 'wo' are supported for the percent_type")
 
     @property
     def enrichment_type(self):
@@ -436,7 +441,8 @@ class Material:
     def volume_of_unit_cell_cm3(self, value):
         if value is not None:
             if value < 0.0:
-                raise ValueError("volume_of_unit_cell_cm3 must be greater than 0")
+                raise ValueError(
+                    "volume_of_unit_cell_cm3 must be greater than 0")
         self._volume_of_unit_cell_cm3 = value
 
     @property
@@ -458,7 +464,8 @@ class Material:
     def temperature_in_C(self, value):
         if value is not None:
             if value < -273.15:
-                raise ValueError("temperature_in_C must be greater than -273.15")
+                raise ValueError(
+                    "temperature_in_C must be greater than -273.15")
         self._temperature_in_C = value
 
     @property
@@ -668,7 +675,8 @@ class Material:
         if isinstance(self.elements, dict):
 
             if self.enrichment_target is not None:
-                enrichment_element = re.split(r"(\d+)", self.enrichment_target)[0]
+                enrichment_element = re.split(
+                    r"(\d+)", self.enrichment_target)[0]
             else:
                 enrichment_element = None
             for element_symbol, element_number in zip(
@@ -731,8 +739,9 @@ class Material:
                 density = eval(self.density_equation)
                 if density is None:
                     raise ValueError(
-                        "Density value of ", self.material_name, " can not be found"
-                    )
+                        "Density value of ",
+                        self.material_name,
+                        " can not be found")
                 else:
                     self.density = density
 
@@ -742,8 +751,8 @@ class Material:
             ):
 
                 molar_mass = (
-                    self._get_atoms_in_crystal() * openmc_material.average_molar_mass
-                )
+                    self._get_atoms_in_crystal() *
+                    openmc_material.average_molar_mass)
 
                 mass = self.atoms_per_unit_cell * molar_mass * atomic_mass_unit_in_g
 
@@ -751,10 +760,10 @@ class Material:
             else:
 
                 raise ValueError(
-                    "density can't be set for "
-                    + str(self.material_name)
-                    + " provide either a density value, equation as a string, or atoms_per_unit_cell and volume_of_unit_cell_cm3"
-                )
+                    "density can't be set for " +
+                    str(
+                        self.material_name) +
+                    " provide either a density value, equation as a string, or atoms_per_unit_cell and volume_of_unit_cell_cm3")
 
         openmc_material.set_density(
             self.density_unit, self.density * self.packing_fraction
@@ -765,7 +774,10 @@ class Material:
     def _get_atoms_in_crystal(self):
         """Finds the number of atoms in the crystal lactic"""
 
-        tokens = [a for a in re.split(r"([A-Z][a-z]*)", self.chemical_equation) if a]
+        tokens = [
+            a for a in re.split(
+                r"([A-Z][a-z]*)",
+                self.chemical_equation) if a]
 
         list_of_fractions = []
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -7,7 +7,11 @@ import re
 from json import JSONEncoder
 from pathlib import Path
 
-import openmc
+try:
+    import openmc
+except ImportError as err:
+    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+
 from CoolProp.CoolProp import PropsSI
 
 from neutronics_material_maker import make_fispact_material, make_serpent_material, make_mcnp_material

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -10,8 +10,9 @@ from pathlib import Path
 import warnings
 try:
     import openmc
-except:
-    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+except BaseException:
+    warnings.warn(
+        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 from CoolProp.CoolProp import PropsSI
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -8,15 +8,22 @@ from json import JSONEncoder
 from pathlib import Path
 
 import warnings
+
 try:
     import openmc
 except BaseException:
     warnings.warn(
-        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+        "OpenMC python package not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material methods not avaiable"
+    )
 
 from CoolProp.CoolProp import PropsSI
 
-from neutronics_material_maker import make_fispact_material, make_serpent_material, make_mcnp_material
+from neutronics_material_maker import (
+    make_fispact_material,
+    make_serpent_material,
+    make_mcnp_material,
+)
+
 atomic_mass_unit_in_g = 1.660539040e-24
 
 
@@ -214,8 +221,7 @@ class Material:
                         "enrichment target and enrichment type are needed to enrich a material"
                     )
 
-            if "temperature_dependant" in material_dict[self.material_name].keys(
-            ):
+            if "temperature_dependant" in material_dict[self.material_name].keys():
                 if temperature_in_K is None and temperature_in_C is None:
                     if self.material_name == "He":
                         raise ValueError(
@@ -239,12 +245,9 @@ class Material:
                     if temperature_in_C is None:
                         self.temperature_in_C = temperature_in_K + 273.15
 
-            if "pressure_dependant" in material_dict[self.material_name].keys(
-            ):
+            if "pressure_dependant" in material_dict[self.material_name].keys():
                 if pressure_in_Pa is None:
-                    raise ValueError(
-                        "pressure_in_Pa is needed for",
-                        self.material_name)
+                    raise ValueError("pressure_in_Pa is needed for", self.material_name)
 
     @property
     def openmc_material(self):
@@ -399,8 +402,7 @@ class Material:
         if value in ["ao", "wo", None]:
             self._percent_type = value
         else:
-            raise ValueError(
-                "only 'ao' and 'wo' are supported for the percent_type")
+            raise ValueError("only 'ao' and 'wo' are supported for the percent_type")
 
     @property
     def enrichment_type(self):
@@ -434,8 +436,7 @@ class Material:
     def volume_of_unit_cell_cm3(self, value):
         if value is not None:
             if value < 0.0:
-                raise ValueError(
-                    "volume_of_unit_cell_cm3 must be greater than 0")
+                raise ValueError("volume_of_unit_cell_cm3 must be greater than 0")
         self._volume_of_unit_cell_cm3 = value
 
     @property
@@ -457,8 +458,7 @@ class Material:
     def temperature_in_C(self, value):
         if value is not None:
             if value < -273.15:
-                raise ValueError(
-                    "temperature_in_C must be greater than -273.15")
+                raise ValueError("temperature_in_C must be greater than -273.15")
         self._temperature_in_C = value
 
     @property
@@ -668,8 +668,7 @@ class Material:
         if isinstance(self.elements, dict):
 
             if self.enrichment_target is not None:
-                enrichment_element = re.split(
-                    r"(\d+)", self.enrichment_target)[0]
+                enrichment_element = re.split(r"(\d+)", self.enrichment_target)[0]
             else:
                 enrichment_element = None
             for element_symbol, element_number in zip(
@@ -732,9 +731,8 @@ class Material:
                 density = eval(self.density_equation)
                 if density is None:
                     raise ValueError(
-                        "Density value of ",
-                        self.material_name,
-                        " can not be found")
+                        "Density value of ", self.material_name, " can not be found"
+                    )
                 else:
                     self.density = density
 
@@ -744,8 +742,7 @@ class Material:
             ):
 
                 molar_mass = (
-                    self._get_atoms_in_crystal()
-                    * openmc_material.average_molar_mass
+                    self._get_atoms_in_crystal() * openmc_material.average_molar_mass
                 )
 
                 mass = self.atoms_per_unit_cell * molar_mass * atomic_mass_unit_in_g
@@ -754,10 +751,10 @@ class Material:
             else:
 
                 raise ValueError(
-                    "density can't be set for " +
-                    str(
-                        self.material_name) +
-                    " provide either a density value, equation as a string, or atoms_per_unit_cell and volume_of_unit_cell_cm3")
+                    "density can't be set for "
+                    + str(self.material_name)
+                    + " provide either a density value, equation as a string, or atoms_per_unit_cell and volume_of_unit_cell_cm3"
+                )
 
         openmc_material.set_density(
             self.density_unit, self.density * self.packing_fraction
@@ -768,10 +765,7 @@ class Material:
     def _get_atoms_in_crystal(self):
         """Finds the number of atoms in the crystal lactic"""
 
-        tokens = [
-            a for a in re.split(
-                r"([A-Z][a-z]*)",
-                self.chemical_equation) if a]
+        tokens = [a for a in re.split(r"([A-Z][a-z]*)", self.chemical_equation) if a]
 
         list_of_fractions = []
 

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -4,7 +4,6 @@ __author__ = "neutronics material maker development team"
 
 import json
 from json import JSONEncoder
-
 import warnings
 
 try:
@@ -101,11 +100,10 @@ class MultiMaterial:
                 "There must be equal numbers of fracs and materials")
 
         if sum(self.fracs) != 1.0:
-            print(
-                "warning sum of MutliMaterials do not sum to 1.",
-                self.fracs,
-                " = ",
-                sum(self.fracs),
+            warnings.warn(
+                "warning sum of MutliMaterials do not sum to 1." +
+                str(self.fracs) + " = " +  str(sum(self.fracs)),
+                UserWarning
             )
 
     @property

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -6,16 +6,22 @@ import json
 from json import JSONEncoder
 
 import warnings
+
 try:
     import openmc
 except BaseException:
     warnings.warn(
-        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+        "OpenMC python package not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material methods not avaiable"
+    )
 
 from CoolProp.CoolProp import PropsSI
 import neutronics_material_maker as nmm
 
-from neutronics_material_maker import make_fispact_material, make_serpent_material, make_mcnp_material
+from neutronics_material_maker import (
+    make_fispact_material,
+    make_serpent_material,
+    make_mcnp_material,
+)
 
 atomic_mass_unit_in_g = 1.660539040e-24
 
@@ -91,8 +97,7 @@ class MultiMaterial:
         self.fispact_material = None
 
         if len(self.fracs) != len(self.materials):
-            raise ValueError(
-                "There must be equal numbers of fracs and materials")
+            raise ValueError("There must be equal numbers of fracs and materials")
 
         if sum(self.fracs) != 1.0:
             print(
@@ -228,7 +233,8 @@ class MultiMaterial:
                     "enrichment_target": material.enrichment_target,
                     "enrichment_type": material.enrichment_type,
                     "reference": material.reference,
-                })
+                }
+            )
 
         jsonified_object = {
             "material_tag": self.material_tag,

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -5,10 +5,11 @@ __author__ = "neutronics material maker development team"
 import json
 from json import JSONEncoder
 
+import warnings
 try:
     import openmc
-except ImportError as err:
-    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+except:
+    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 from CoolProp.CoolProp import PropsSI
 import neutronics_material_maker as nmm

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -97,7 +97,8 @@ class MultiMaterial:
         self.fispact_material = None
 
         if len(self.fracs) != len(self.materials):
-            raise ValueError("There must be equal numbers of fracs and materials")
+            raise ValueError(
+                "There must be equal numbers of fracs and materials")
 
         if sum(self.fracs) != 1.0:
             print(
@@ -233,8 +234,7 @@ class MultiMaterial:
                     "enrichment_target": material.enrichment_target,
                     "enrichment_type": material.enrichment_type,
                     "reference": material.reference,
-                }
-            )
+                })
 
         jsonified_object = {
             "material_tag": self.material_tag,

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -8,8 +8,9 @@ from json import JSONEncoder
 import warnings
 try:
     import openmc
-except:
-    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+except BaseException:
+    warnings.warn(
+        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 from CoolProp.CoolProp import PropsSI
 import neutronics_material_maker as nmm

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -102,7 +102,7 @@ class MultiMaterial:
         if sum(self.fracs) != 1.0:
             warnings.warn(
                 "warning sum of MutliMaterials do not sum to 1." +
-                str(self.fracs) + " = " +  str(sum(self.fracs)),
+                str(self.fracs) + " = " + str(sum(self.fracs)),
                 UserWarning
             )
 

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -5,7 +5,11 @@ __author__ = "neutronics material maker development team"
 import json
 from json import JSONEncoder
 
-import openmc
+try:
+    import openmc
+except ImportError as err:
+    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+
 from CoolProp.CoolProp import PropsSI
 import neutronics_material_maker as nmm
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -1,9 +1,9 @@
 import warnings
 try:
     import openmc
-except:
-    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
-
+except BaseException:
+    warnings.warn(
+        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 
 def make_fispact_material(mat):

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -1,7 +1,8 @@
+import warnings
 try:
     import openmc
-except ImportError as err:
-    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+except:
+    warnings.warn('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
 
 
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -52,7 +52,8 @@ def make_serpent_material(mat):
     else:
         zaid_suffix = mat.zaid_suffix
 
-    mat_card = ["mat " + name + " " + str(mat.openmc_material.get_mass_density())]
+    mat_card = ["mat " + name + " " +
+                str(mat.openmc_material.get_mass_density())]
     # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:
@@ -108,7 +109,8 @@ def make_mcnp_material(mat):
         elif isotope[2] == "wo":
             prefix = " -"
 
-        rest = isotope_to_zaid(isotope[0]) + zaid_suffix + prefix + str(isotope[1])
+        rest = isotope_to_zaid(isotope[0]) + \
+            zaid_suffix + prefix + str(isotope[1])
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -1,9 +1,15 @@
+#!/usr/bin/env python3
+
+__author__ = "neutronics material maker development team"
+
 import warnings
+
 try:
     import openmc
 except BaseException:
     warnings.warn(
-        'OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+        "OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable"
+    )
 
 
 def make_fispact_material(mat):
@@ -23,8 +29,11 @@ def make_fispact_material(mat):
         "DENSITY " + str(mat.openmc_material.get_mass_density()),
         "FUEL " + str(len(mat.openmc_material.nuclides)),
     ]
-    for isotope, atoms_barn_cm in mat.openmc_material.get_nuclide_atom_densities().values():
-        atoms_cm3 = atoms_barn_cm * 1.e24
+    for (
+        isotope,
+        atoms_barn_cm,
+    ) in mat.openmc_material.get_nuclide_atom_densities().values():
+        atoms_cm3 = atoms_barn_cm * 1.0e24
         atoms = mat.volume_in_cm3 * atoms_cm3
         mat_card.append(isotope + " " + "{:.12E}".format(atoms))
 
@@ -43,8 +52,7 @@ def make_serpent_material(mat):
     else:
         zaid_suffix = mat.zaid_suffix
 
-    mat_card = ["mat " + name + " " +
-                str(mat.openmc_material.get_mass_density())]
+    mat_card = ["mat " + name + " " + str(mat.openmc_material.get_mass_density())]
     # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:
@@ -81,8 +89,13 @@ def make_mcnp_material(mat):
     else:
         zaid_suffix = mat.zaid_suffix
 
-    mat_card = ['c     ' + name + ' density ' +
-                str(mat.openmc_material.get_mass_density()) + ' g/cm3']
+    mat_card = [
+        "c     "
+        + name
+        + " density "
+        + str(mat.openmc_material.get_mass_density())
+        + " g/cm3"
+    ]
     for i, isotope in enumerate(mat.openmc_material.nuclides):
 
         if i == 0:
@@ -95,12 +108,7 @@ def make_mcnp_material(mat):
         elif isotope[2] == "wo":
             prefix = " -"
 
-        rest = (
-            isotope_to_zaid(isotope[0])
-            + zaid_suffix
-            + prefix
-            + str(isotope[1])
-        )
+        rest = isotope_to_zaid(isotope[0]) + zaid_suffix + prefix + str(isotope[1])
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -1,4 +1,8 @@
-import openmc
+try:
+    import openmc
+except ImportError as err:
+    raise err('OpenMC not found, .openmc_material, .serpent_material, .mcnp_material, .fispact_material not avaiable')
+
 
 
 def make_fispact_material(mat):

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -77,7 +77,7 @@ def make_mcnp_material(mat):
 
     if mat.id is None:
         raise ValueError(
-            "Material.id needs setting before serpent_material can be made"
+            "Material.id needs setting before mcnp_material can be made"
         )
 
     if mat.material_tag is None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1237",
+    version="0.1238",
     summary="Package for making material cards for OpenMC",
     author="neutronics-material-maker development team",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -36,7 +36,8 @@ import neutronics_material_maker as nmm
 class test_object_properties(unittest.TestCase):
     def test_fispact_material(self):
         a = nmm.Material("Li4SiO4", volume_in_cm3=1.0)
-        assert a.fispact_material.split("\n")[-9] == "DENSITY 2.3186896075603562"
+        assert a.fispact_material.split(
+            "\n")[-9] == "DENSITY 2.3186896075603562"
         assert a.fispact_material.split("\n")[-8] == "FUEL 7"
         assert a.fispact_material.split("\n")[-7] == "Li6 3.537400925715E+21"
         assert a.fispact_material.split("\n")[-6] == "Li7 4.307481314353E+22"
@@ -49,7 +50,8 @@ class test_object_properties(unittest.TestCase):
 
     def test_fispact_material_with_volume(self):
         a = nmm.Material("Li4SiO4", volume_in_cm3=2.0)
-        assert a.fispact_material.split("\n")[-9] == "DENSITY 2.3186896075603562"
+        assert a.fispact_material.split(
+            "\n")[-9] == "DENSITY 2.3186896075603562"
         assert a.fispact_material.split("\n")[-8] == "FUEL 7"
         assert a.fispact_material.split("\n")[-7] == "Li6 7.074801851431E+21"
         assert a.fispact_material.split("\n")[-6] == "Li7 8.614962628707E+22"
@@ -103,9 +105,11 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[11] == "     050124.30c  0.014475"
 
     def test_serpent_material_suffix(self):
-        test_material1 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c")
+        test_material1 = nmm.Material(
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c")
         serpent_material1 = test_material1.serpent_material
-        test_material2 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c")
+        test_material2 = nmm.Material(
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c")
         serpent_material2 = test_material2.serpent_material
         test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn")
         serpent_material3 = test_material3.serpent_material
@@ -246,10 +250,12 @@ class test_object_properties(unittest.TestCase):
         lead_fraction = 3
         lithium_fraction = 7
 
-        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + \
+            str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
-            "lithium-lead", elements=lithium_lead_elements, temperature_in_C=450
-        )
+            "lithium-lead",
+            elements=lithium_lead_elements,
+            temperature_in_C=450)
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
         li_atom_count = 0
@@ -267,7 +273,8 @@ class test_object_properties(unittest.TestCase):
         lithium_fraction = 7
         enrichment = 20
 
-        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + \
+            str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
@@ -291,8 +298,10 @@ class test_object_properties(unittest.TestCase):
             if entry[0] == "Li7":
                 li7_atom_count = li7_atom_count + entry[1]
         print(nucs)
-        assert pb_atom_count == lead_fraction / (lead_fraction + lithium_fraction)
-        assert li_atom_count == lithium_fraction / (lead_fraction + lithium_fraction)
+        assert pb_atom_count == lead_fraction / \
+            (lead_fraction + lithium_fraction)
+        assert li_atom_count == lithium_fraction / \
+            (lead_fraction + lithium_fraction)
         assert li6_atom_count * 4.0 == pytest.approx(li7_atom_count)
 
         assert li6_atom_count == pytest.approx(
@@ -312,7 +321,8 @@ class test_object_properties(unittest.TestCase):
         lithium_fraction = 7
         enrichment = 20
 
-        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + \
+            str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
@@ -352,34 +362,44 @@ class test_object_properties(unittest.TestCase):
         # however, this could be becuase the density values are rounded to 2 dp
 
         test_material = nmm.Material(material_name="Li4SiO4")
-        assert test_material.openmc_material.density == pytest.approx(2.32, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            2.32, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2SiO3")
-        assert test_material.openmc_material.density == pytest.approx(2.44, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            2.44, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2ZrO3")
-        assert test_material.openmc_material.density == pytest.approx(4.03, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            4.03, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2TiO3")
-        assert test_material.openmc_material.density == pytest.approx(3.34, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            3.34, rel=0.01)
 
         test_material = nmm.Material(material_name="Li8PbO6")
-        assert test_material.openmc_material.density == pytest.approx(4.14, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            4.14, rel=0.01)
 
         test_material = nmm.Material(material_name="Be")
-        assert test_material.openmc_material.density == pytest.approx(1.88, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            1.88, rel=0.01)
 
         test_material = nmm.Material(material_name="Be12Ti")
-        assert test_material.openmc_material.density == pytest.approx(2.28, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            2.28, rel=0.01)
 
         test_material = nmm.Material(material_name="Ba5Pb3")
-        assert test_material.openmc_material.density == pytest.approx(5.84, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            5.84, rel=0.01)
 
         test_material = nmm.Material(material_name="Nd5Pb4")
-        assert test_material.openmc_material.density == pytest.approx(8.79, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            8.79, rel=0.01)
 
         test_material = nmm.Material(material_name="Zr5Pb3")
-        assert test_material.openmc_material.density == pytest.approx(8.23, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(
+            8.23, rel=0.01)
 
         # test_material = nmm.Material(material_name="Zr5Pb4")
         # assert test_material.openmc_material.density ==
@@ -417,10 +437,12 @@ class test_object_properties(unittest.TestCase):
         lead_fraction = 3
         lithium_fraction = 7
 
-        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + \
+            str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
-            "lithium-lead", elements=lithium_lead_elements, temperature_in_C=450
-        )
+            "lithium-lead",
+            elements=lithium_lead_elements,
+            temperature_in_C=450)
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
         li_atom_count = 0
@@ -429,8 +451,10 @@ class test_object_properties(unittest.TestCase):
                 pb_atom_count = pb_atom_count + entry[1]
             if entry[0].startswith("Li"):
                 li_atom_count = li_atom_count + entry[1]
-        assert pb_atom_count == lead_fraction / (lead_fraction + lithium_fraction)
-        assert li_atom_count == lithium_fraction / (lead_fraction + lithium_fraction)
+        assert pb_atom_count == lead_fraction / \
+            (lead_fraction + lithium_fraction)
+        assert li_atom_count == lithium_fraction / \
+            (lead_fraction + lithium_fraction)
 
     def test_incorrect_settings(self):
         def incorrect_temperature_in_K():
@@ -473,11 +497,13 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_reference_type)
 
     def test_json_dump_works(self):
-        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material(
+            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         assert isinstance(json.dumps(test_material), str)
 
     def test_json_dump_contains_correct_keys(self):
-        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material(
+            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert "atoms_per_unit_cell" in test_material_in_json_form.keys()
@@ -500,7 +526,8 @@ class test_object_properties(unittest.TestCase):
         assert "volume_of_unit_cell_cm3" in test_material_in_json_form.keys()
 
     def test_json_dump_contains_correct_values(self):
-        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material(
+            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert test_material_in_json_form["pressure_in_Pa"] == 1e6

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -104,6 +104,32 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[10] == "     050122.30c  0.011575"
         assert line_by_line_material[11] == "     050124.30c  0.014475"
 
+    def test_mcnp_material_lines(self):
+        test_material = nmm.Material(
+            elements="Nb3Sn", material_tag="test2", density=3.2, density_unit='g/cm3',
+            id=1, percent_type='wo'
+        )
+        mcnp_material = test_material.mcnp_material
+        line_by_line_material = mcnp_material.split("\n")
+
+        assert line_by_line_material[0].split()[0] == "c"
+        assert line_by_line_material[0].split()[1] == "test2"
+        assert line_by_line_material[0].split()[2] == "density"
+        assert float(line_by_line_material[0].split()[3]) == pytest.approx(3.2)
+        assert line_by_line_material[0].split()[4] == "g/cm3"
+
+        assert '-' in line_by_line_material[1]
+        assert '-' in line_by_line_material[2]
+        assert '-' in line_by_line_material[3]
+        assert '-' in line_by_line_material[4]
+        assert '-' in line_by_line_material[5]
+        assert '-' in line_by_line_material[6]
+        assert '-' in line_by_line_material[7]
+        assert '-' in line_by_line_material[8]
+        assert '-' in line_by_line_material[9]
+        assert '-' in line_by_line_material[10]
+        assert '-' in line_by_line_material[11]
+
     def test_serpent_material_suffix(self):
         test_material1 = nmm.Material(
             "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c")
@@ -484,7 +510,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_enrichment_target)
 
         def incorrect_reference_type():
-            """checks a ValueError is raised when the refernces is the wrong type"""
+            """checks a ValueError is raised when the reference is the wrong type"""
 
             nmm.Material(
                 material_name="Li4SiO4",
@@ -495,6 +521,23 @@ class test_object_properties(unittest.TestCase):
             )
 
         self.assertRaises(ValueError, incorrect_reference_type)
+
+        def incorrect_setting_for_id():
+            """checks a ValueError is raised when the id is not set and an mcnp material card is need"""
+
+            test_material = nmm.Material(
+                material_name="Li4SiO4",
+                enrichment=50.0,
+                enrichment_target="Li6",
+                enrichment_type="ao",
+                reference=1,
+            )
+
+            test_material.export_mcnp
+
+        self.assertRaises(ValueError, incorrect_setting_for_id)
+
+
 
     def test_json_dump_works(self):
         test_material = nmm.Material(
@@ -533,7 +576,6 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["pressure_in_Pa"] == 1e6
         assert test_material_in_json_form["temperature_in_C"] == 100
         assert test_material_in_json_form["material_name"] == "H2O"
-
 
 if __name__ == "__main__":
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -106,9 +106,12 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
-            elements="Nb3Sn", material_tag="test2", density=3.2, density_unit='g/cm3',
-            id=1, percent_type='wo'
-        )
+            elements="Nb3Sn",
+            material_tag="test2",
+            density=3.2,
+            density_unit='g/cm3',
+            id=1,
+            percent_type='wo')
         mcnp_material = test_material.mcnp_material
         line_by_line_material = mcnp_material.split("\n")
 
@@ -132,9 +135,12 @@ class test_object_properties(unittest.TestCase):
 
     def test_serpent_material_lines_contain_underscore(self):
         test_material = nmm.Material(
-            elements="Nb3Sn", material_tag="test2", density=3.2, density_unit='g/cm3',
-            id=1, percent_type='wo'
-        )
+            elements="Nb3Sn",
+            material_tag="test2",
+            density=3.2,
+            density_unit='g/cm3',
+            id=1,
+            percent_type='wo')
         serpent_material = test_material.serpent_material
         line_by_line_material = serpent_material.split("\n")
 
@@ -561,8 +567,6 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, incorrect_setting_for_id)
 
-
-
     def test_json_dump_works(self):
         test_material = nmm.Material(
             "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
@@ -600,6 +604,7 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["pressure_in_Pa"] == 1e6
         assert test_material_in_json_form["temperature_in_C"] == 100
         assert test_material_in_json_form["material_name"] == "H2O"
+
 
 if __name__ == "__main__":
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -104,7 +104,7 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[10] == "     050122.30c  0.011575"
         assert line_by_line_material[11] == "     050124.30c  0.014475"
 
-    def test_mcnp_material_lines(self):
+    def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
             elements="Nb3Sn", material_tag="test2", density=3.2, density_unit='g/cm3',
             id=1, percent_type='wo'
@@ -117,6 +117,30 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[0].split()[2] == "density"
         assert float(line_by_line_material[0].split()[3]) == pytest.approx(3.2)
         assert line_by_line_material[0].split()[4] == "g/cm3"
+
+        assert '-' in line_by_line_material[1]
+        assert '-' in line_by_line_material[2]
+        assert '-' in line_by_line_material[3]
+        assert '-' in line_by_line_material[4]
+        assert '-' in line_by_line_material[5]
+        assert '-' in line_by_line_material[6]
+        assert '-' in line_by_line_material[7]
+        assert '-' in line_by_line_material[8]
+        assert '-' in line_by_line_material[9]
+        assert '-' in line_by_line_material[10]
+        assert '-' in line_by_line_material[11]
+
+    def test_serpent_material_lines_contain_underscore(self):
+        test_material = nmm.Material(
+            elements="Nb3Sn", material_tag="test2", density=3.2, density_unit='g/cm3',
+            id=1, percent_type='wo'
+        )
+        serpent_material = test_material.serpent_material
+        line_by_line_material = serpent_material.split("\n")
+
+        assert line_by_line_material[0].split()[0] == "mat"
+        assert line_by_line_material[0].split()[1] == "test2"
+        assert float(line_by_line_material[0].split()[2]) == pytest.approx(3.2)
 
         assert '-' in line_by_line_material[1]
         assert '-' in line_by_line_material[2]

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -34,53 +34,40 @@ import neutronics_material_maker as nmm
 
 
 class test_object_properties(unittest.TestCase):
-
     def test_fispact_material(self):
-        a = nmm.Material('Li4SiO4', volume_in_cm3=1.)
-        assert a.fispact_material.split(
-            '\n')[-9] == 'DENSITY 2.3186896075603562'
-        assert a.fispact_material.split('\n')[-8] == 'FUEL 7'
-        assert a.fispact_material.split('\n')[-7] == 'Li6 3.537400925715E+21'
-        assert a.fispact_material.split('\n')[-6] == 'Li7 4.307481314353E+22'
-        assert a.fispact_material.split(
-            '\n')[-5] == 'Si28 1.074757396925E+22'
-        assert a.fispact_material.split(
-            '\n')[-4] == 'Si29 5.457311411014E+20'
-        assert a.fispact_material.split(
-            '\n')[-3] == 'Si30 3.597484069651E+20'
-        assert a.fispact_material.split('\n')[-2] == 'O16 4.659454804012E+22'
-        assert a.fispact_material.split('\n')[-1] == 'O17 1.766602913225E+19'
+        a = nmm.Material("Li4SiO4", volume_in_cm3=1.0)
+        assert a.fispact_material.split("\n")[-9] == "DENSITY 2.3186896075603562"
+        assert a.fispact_material.split("\n")[-8] == "FUEL 7"
+        assert a.fispact_material.split("\n")[-7] == "Li6 3.537400925715E+21"
+        assert a.fispact_material.split("\n")[-6] == "Li7 4.307481314353E+22"
+        assert a.fispact_material.split("\n")[-5] == "Si28 1.074757396925E+22"
+        assert a.fispact_material.split("\n")[-4] == "Si29 5.457311411014E+20"
+        assert a.fispact_material.split("\n")[-3] == "Si30 3.597484069651E+20"
+        assert a.fispact_material.split("\n")[-2] == "O16 4.659454804012E+22"
+        assert a.fispact_material.split("\n")[-1] == "O17 1.766602913225E+19"
         # assert a.fispact_material(volume=1).split('\n')[-1] == 'O18 4.532562645'
 
     def test_fispact_material_with_volume(self):
-        a = nmm.Material('Li4SiO4', volume_in_cm3=2.)
-        assert a.fispact_material.split(
-            '\n')[-9] == 'DENSITY 2.3186896075603562'
-        assert a.fispact_material.split('\n')[-8] == 'FUEL 7'
-        assert a.fispact_material.split('\n')[-7] == 'Li6 7.074801851431E+21'
-        assert a.fispact_material.split('\n')[-6] == 'Li7 8.614962628707E+22'
-        assert a.fispact_material.split(
-            '\n')[-5] == 'Si28 2.149514793849E+22'
-        assert a.fispact_material.split(
-            '\n')[-4] == 'Si29 1.091462282203E+21'
-        assert a.fispact_material.split(
-            '\n')[-3] == 'Si30 7.194968139301E+20'
-        assert a.fispact_material.split('\n')[-2] == 'O16 9.318909608023E+22'
-        assert a.fispact_material.split('\n')[-1] == 'O17 3.533205826449E+19'
+        a = nmm.Material("Li4SiO4", volume_in_cm3=2.0)
+        assert a.fispact_material.split("\n")[-9] == "DENSITY 2.3186896075603562"
+        assert a.fispact_material.split("\n")[-8] == "FUEL 7"
+        assert a.fispact_material.split("\n")[-7] == "Li6 7.074801851431E+21"
+        assert a.fispact_material.split("\n")[-6] == "Li7 8.614962628707E+22"
+        assert a.fispact_material.split("\n")[-5] == "Si28 2.149514793849E+22"
+        assert a.fispact_material.split("\n")[-4] == "Si29 1.091462282203E+21"
+        assert a.fispact_material.split("\n")[-3] == "Si30 7.194968139301E+20"
+        assert a.fispact_material.split("\n")[-2] == "O16 9.318909608023E+22"
+        assert a.fispact_material.split("\n")[-1] == "O17 3.533205826449E+19"
         # assert a.fispact_material(volume=1).split('\n')[-1] == 'O18 4.532562645'
 
     def test_mcnp_material_suffix(self):
         test_material1 = nmm.Material(
-            "Nb3Sn",
-            material_tag="Nb3Sn",
-            zaid_suffix=".21c",
-            id=27)
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c", id=27
+        )
         mcnp_material1 = test_material1.mcnp_material
         test_material2 = nmm.Material(
-            "Nb3Sn",
-            material_tag="Nb3Sn",
-            zaid_suffix=".30c",
-            id=27)
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c", id=27
+        )
         mcnp_material2 = test_material2.mcnp_material
         test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", id=27)
         mcnp_material3 = test_material3.mcnp_material
@@ -91,19 +78,16 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_lines(self):
         test_material = nmm.Material(
-            "Nb3Sn",
-            material_tag="test",
-            density=3,
-            zaid_suffix=".30c",
-            id=27)
+            "Nb3Sn", material_tag="test", density=3, zaid_suffix=".30c", id=27
+        )
         mcnp_material = test_material.mcnp_material
         line_by_line_material = mcnp_material.split("\n")
 
-        assert line_by_line_material[0].split()[0] == 'c'
-        assert line_by_line_material[0].split()[1] == 'test'
-        assert line_by_line_material[0].split()[2] == 'density'
+        assert line_by_line_material[0].split()[0] == "c"
+        assert line_by_line_material[0].split()[1] == "test"
+        assert line_by_line_material[0].split()[2] == "density"
         assert float(line_by_line_material[0].split()[3]) == 3
-        assert line_by_line_material[0].split()[4] == 'g/cm3'
+        assert line_by_line_material[0].split()[4] == "g/cm3"
 
         assert line_by_line_material[1] == "M27 041093.30c  0.75"
 
@@ -119,11 +103,9 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[11] == "     050124.30c  0.014475"
 
     def test_serpent_material_suffix(self):
-        test_material1 = nmm.Material(
-            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c")
+        test_material1 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c")
         serpent_material1 = test_material1.serpent_material
-        test_material2 = nmm.Material(
-            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c")
+        test_material2 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c")
         serpent_material2 = test_material2.serpent_material
         test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn")
         serpent_material3 = test_material3.serpent_material
@@ -134,15 +116,13 @@ class test_object_properties(unittest.TestCase):
 
     def test_serpent_material_lines(self):
         test_material = nmm.Material(
-            "Nb3Sn",
-            material_tag="test",
-            density=3,
-            zaid_suffix=".30c")
+            "Nb3Sn", material_tag="test", density=3, zaid_suffix=".30c"
+        )
         serpent_material = test_material.serpent_material
         line_by_line_material = serpent_material.split("\n")
 
-        assert line_by_line_material[0].split()[0] == 'mat'
-        assert line_by_line_material[0].split()[1] == 'test'
+        assert line_by_line_material[0].split()[0] == "mat"
+        assert line_by_line_material[0].split()[1] == "test"
         assert float(line_by_line_material[0].split()[2]) == 3
         assert line_by_line_material[1] == "     041093.30c  0.75"
         assert line_by_line_material[2] == "     050112.30c  0.002425"
@@ -266,12 +246,10 @@ class test_object_properties(unittest.TestCase):
         lead_fraction = 3
         lithium_fraction = 7
 
-        lithium_lead_elements = "Li" + \
-            str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
-            "lithium-lead",
-            elements=lithium_lead_elements,
-            temperature_in_C=450)
+            "lithium-lead", elements=lithium_lead_elements, temperature_in_C=450
+        )
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
         li_atom_count = 0
@@ -289,8 +267,7 @@ class test_object_properties(unittest.TestCase):
         lithium_fraction = 7
         enrichment = 20
 
-        lithium_lead_elements = "Li" + \
-            str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
@@ -314,10 +291,8 @@ class test_object_properties(unittest.TestCase):
             if entry[0] == "Li7":
                 li7_atom_count = li7_atom_count + entry[1]
         print(nucs)
-        assert pb_atom_count == lead_fraction / \
-            (lead_fraction + lithium_fraction)
-        assert li_atom_count == lithium_fraction / \
-            (lead_fraction + lithium_fraction)
+        assert pb_atom_count == lead_fraction / (lead_fraction + lithium_fraction)
+        assert li_atom_count == lithium_fraction / (lead_fraction + lithium_fraction)
         assert li6_atom_count * 4.0 == pytest.approx(li7_atom_count)
 
         assert li6_atom_count == pytest.approx(
@@ -337,8 +312,7 @@ class test_object_properties(unittest.TestCase):
         lithium_fraction = 7
         enrichment = 20
 
-        lithium_lead_elements = "Li" + \
-            str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
             "lithium-lead",
             enrichment=enrichment,
@@ -378,44 +352,34 @@ class test_object_properties(unittest.TestCase):
         # however, this could be becuase the density values are rounded to 2 dp
 
         test_material = nmm.Material(material_name="Li4SiO4")
-        assert test_material.openmc_material.density == pytest.approx(
-            2.32, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(2.32, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2SiO3")
-        assert test_material.openmc_material.density == pytest.approx(
-            2.44, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(2.44, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2ZrO3")
-        assert test_material.openmc_material.density == pytest.approx(
-            4.03, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(4.03, rel=0.01)
 
         test_material = nmm.Material(material_name="Li2TiO3")
-        assert test_material.openmc_material.density == pytest.approx(
-            3.34, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(3.34, rel=0.01)
 
         test_material = nmm.Material(material_name="Li8PbO6")
-        assert test_material.openmc_material.density == pytest.approx(
-            4.14, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(4.14, rel=0.01)
 
         test_material = nmm.Material(material_name="Be")
-        assert test_material.openmc_material.density == pytest.approx(
-            1.88, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(1.88, rel=0.01)
 
         test_material = nmm.Material(material_name="Be12Ti")
-        assert test_material.openmc_material.density == pytest.approx(
-            2.28, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(2.28, rel=0.01)
 
         test_material = nmm.Material(material_name="Ba5Pb3")
-        assert test_material.openmc_material.density == pytest.approx(
-            5.84, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(5.84, rel=0.01)
 
         test_material = nmm.Material(material_name="Nd5Pb4")
-        assert test_material.openmc_material.density == pytest.approx(
-            8.79, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(8.79, rel=0.01)
 
         test_material = nmm.Material(material_name="Zr5Pb3")
-        assert test_material.openmc_material.density == pytest.approx(
-            8.23, rel=0.01)
+        assert test_material.openmc_material.density == pytest.approx(8.23, rel=0.01)
 
         # test_material = nmm.Material(material_name="Zr5Pb4")
         # assert test_material.openmc_material.density ==
@@ -453,12 +417,10 @@ class test_object_properties(unittest.TestCase):
         lead_fraction = 3
         lithium_fraction = 7
 
-        lithium_lead_elements = "Li" + \
-            str(lithium_fraction) + "Pb" + str(lead_fraction)
+        lithium_lead_elements = "Li" + str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
-            "lithium-lead",
-            elements=lithium_lead_elements,
-            temperature_in_C=450)
+            "lithium-lead", elements=lithium_lead_elements, temperature_in_C=450
+        )
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
         li_atom_count = 0
@@ -467,10 +429,8 @@ class test_object_properties(unittest.TestCase):
                 pb_atom_count = pb_atom_count + entry[1]
             if entry[0].startswith("Li"):
                 li_atom_count = li_atom_count + entry[1]
-        assert pb_atom_count == lead_fraction / \
-            (lead_fraction + lithium_fraction)
-        assert li_atom_count == lithium_fraction / \
-            (lead_fraction + lithium_fraction)
+        assert pb_atom_count == lead_fraction / (lead_fraction + lithium_fraction)
+        assert li_atom_count == lithium_fraction / (lead_fraction + lithium_fraction)
 
     def test_incorrect_settings(self):
         def incorrect_temperature_in_K():
@@ -513,13 +473,11 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_reference_type)
 
     def test_json_dump_works(self):
-        test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         assert isinstance(json.dumps(test_material), str)
 
     def test_json_dump_contains_correct_keys(self):
-        test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert "atoms_per_unit_cell" in test_material_in_json_form.keys()
@@ -542,8 +500,7 @@ class test_object_properties(unittest.TestCase):
         assert "volume_of_unit_cell_cm3" in test_material_in_json_form.keys()
 
     def test_json_dump_contains_correct_values(self):
-        test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+        test_material = nmm.Material("H2O", temperature_in_C=100, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert test_material_in_json_form["pressure_in_Pa"] == 1e6

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -116,7 +116,8 @@ class test_object_properties(unittest.TestCase):
         assert isinstance(test_material, openmc.Material) == False
         assert isinstance(test_material.openmc_material, openmc.Material)
 
-    def test_multimaterial_attributes_from_material_objects_and_openmc_materials(self):
+    def test_multimaterial_attributes_from_material_objects_and_openmc_materials(
+            self):
         # tests that multimaterials made from material objects and neutronics
         # materials have the same properties
 
@@ -194,10 +195,12 @@ class test_object_properties(unittest.TestCase):
 
     def test_density_of_mixed_materials_from_density_equation(self):
 
-        test_material = nmm.Material("H2O", temperature_in_C=25, pressure_in_Pa=100000)
+        test_material = nmm.Material(
+            "H2O", temperature_in_C=25, pressure_in_Pa=100000)
         test_mixed_material = nmm.MultiMaterial(
-            material_tag="test_mixed_material", materials=[test_material], fracs=[1]
-        )
+            material_tag="test_mixed_material",
+            materials=[test_material],
+            fracs=[1])
 
         assert (
             test_material.openmc_material.density
@@ -234,17 +237,22 @@ class test_object_properties(unittest.TestCase):
 
         test_material_1 = nmm.Material("Li4SiO4").openmc_material
 
-        test_material_2 = nmm.Material("Li4SiO4", packing_fraction=1).openmc_material
+        test_material_2 = nmm.Material(
+            "Li4SiO4", packing_fraction=1).openmc_material
 
         assert test_material_1.density == test_material_2.density
 
-        test_material_3 = nmm.Material("Li4SiO4", packing_fraction=0.5).openmc_material
+        test_material_3 = nmm.Material(
+            "Li4SiO4", packing_fraction=0.5).openmc_material
 
-        assert test_material_3.density == pytest.approx(test_material_1.density * 0.5)
+        assert test_material_3.density == pytest.approx(
+            test_material_1.density * 0.5)
 
-        test_material_4 = nmm.Material("Li4SiO4", packing_fraction=0.75).openmc_material
+        test_material_4 = nmm.Material(
+            "Li4SiO4", packing_fraction=0.75).openmc_material
 
-        assert test_material_4.density == pytest.approx(test_material_1.density * 0.75)
+        assert test_material_4.density == pytest.approx(
+            test_material_1.density * 0.75)
 
     def test_packing_fraction_for_multimaterial_function(self):
 
@@ -274,7 +282,8 @@ class test_object_properties(unittest.TestCase):
             fracs=[0.5, 0.5],
         ).openmc_material
 
-        assert test_material_7.density == pytest.approx(test_material_5.density * 0.5)
+        assert test_material_7.density == pytest.approx(
+            test_material_5.density * 0.5)
 
     def test_packing_fraction_of_a_multimaterial(self):
 
@@ -335,7 +344,8 @@ class test_object_properties(unittest.TestCase):
             percent_type="vo",
         )
 
-        assert test_material_10.density == pytest.approx(test_material_8.density * 0.5)
+        assert test_material_10.density == pytest.approx(
+            test_material_8.density * 0.5)
 
     def test_multimaterial_vs_mix_materials(self):
 

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -456,7 +456,8 @@ class test_object_properties(unittest.TestCase):
             # Verify some things
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
-            assert "warning sum of MutliMaterials do not sum to 1." in str(w[-1].message)
+            assert "warning sum of MutliMaterials do not sum to 1." in str(
+                w[-1].message)
 
         def too_small_fracs():
             """checks a ValueError is raised when the fracs are above 1"""
@@ -478,4 +479,5 @@ class test_object_properties(unittest.TestCase):
             # Verify some things
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
-            assert "warning sum of MutliMaterials do not sum to 1." in str(w[-1].message)
+            assert "warning sum of MutliMaterials do not sum to 1." in str(
+                w[-1].message)

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -47,7 +47,6 @@ if __name__ == "__main__":
 
 
 class test_object_properties(unittest.TestCase):
-
     def test_serpent_multimaterial_type(self):
 
         test_material = nmm.MultiMaterial(
@@ -67,7 +66,7 @@ class test_object_properties(unittest.TestCase):
             materials=[nmm.Material("Li4SiO4"), nmm.Material("Be12Ti")],
             fracs=[0.50, 0.50],
             percent_type="vo",
-            id=2
+            id=2,
         )
 
         assert len(test_material.mcnp_material) > 100
@@ -80,7 +79,7 @@ class test_object_properties(unittest.TestCase):
             materials=[nmm.Material("Li4SiO4"), nmm.Material("Be12Ti")],
             fracs=[0.50, 0.50],
             percent_type="vo",
-            volume_in_cm3=20
+            volume_in_cm3=20,
         )
 
         assert len(test_material.fispact_material) > 100
@@ -117,8 +116,7 @@ class test_object_properties(unittest.TestCase):
         assert isinstance(test_material, openmc.Material) == False
         assert isinstance(test_material.openmc_material, openmc.Material)
 
-    def test_multimaterial_attributes_from_material_objects_and_openmc_materials(
-            self):
+    def test_multimaterial_attributes_from_material_objects_and_openmc_materials(self):
         # tests that multimaterials made from material objects and neutronics
         # materials have the same properties
 
@@ -155,7 +153,8 @@ class test_object_properties(unittest.TestCase):
 
         test_material_2 = nmm.Material(material_name="Be12Ti")
         test_material_packed_2 = nmm.Material(
-            material_name="Be12Ti", packing_fraction=0.35)
+            material_name="Be12Ti", packing_fraction=0.35
+        )
         assert (
             test_material_2.openmc_material.density * 0.35
             == test_material_packed_2.openmc_material.density
@@ -169,8 +168,10 @@ class test_object_properties(unittest.TestCase):
         )
 
         assert mixed_packed_crystals.openmc_material.density == pytest.approx(
-            (test_material_1.openmc_material.density * 0.65 * 0.75) + (
-                test_material_2.openmc_material.density * 0.35 * 0.25), rel=0.01, )
+            (test_material_1.openmc_material.density * 0.65 * 0.75)
+            + (test_material_2.openmc_material.density * 0.35 * 0.25),
+            rel=0.01,
+        )
 
     def test_density_of_mixed_two_packed_and_non_packed_crystals(self):
 
@@ -193,14 +194,10 @@ class test_object_properties(unittest.TestCase):
 
     def test_density_of_mixed_materials_from_density_equation(self):
 
-        test_material = nmm.Material(
-            "H2O",
-            temperature_in_C=25,
-            pressure_in_Pa=100000)
+        test_material = nmm.Material("H2O", temperature_in_C=25, pressure_in_Pa=100000)
         test_mixed_material = nmm.MultiMaterial(
-            material_tag="test_mixed_material",
-            materials=[test_material],
-            fracs=[1])
+            material_tag="test_mixed_material", materials=[test_material], fracs=[1]
+        )
 
         assert (
             test_material.openmc_material.density
@@ -225,31 +222,29 @@ class test_object_properties(unittest.TestCase):
             percent_type="vo",
         )
 
-        assert mixed_packed_crystal_and_non_crystal.openmc_material.density == pytest.approx(
-            (test_material_1.openmc_material.density * 0.5)
-            + (test_material_2.openmc_material.density * 0.65 * 0.5)
+        assert (
+            mixed_packed_crystal_and_non_crystal.openmc_material.density
+            == pytest.approx(
+                (test_material_1.openmc_material.density * 0.5)
+                + (test_material_2.openmc_material.density * 0.65 * 0.5)
+            )
         )
 
     def test_packing_fraction_for_single_materials(self):
 
         test_material_1 = nmm.Material("Li4SiO4").openmc_material
 
-        test_material_2 = nmm.Material(
-            "Li4SiO4", packing_fraction=1).openmc_material
+        test_material_2 = nmm.Material("Li4SiO4", packing_fraction=1).openmc_material
 
         assert test_material_1.density == test_material_2.density
 
-        test_material_3 = nmm.Material(
-            "Li4SiO4", packing_fraction=0.5).openmc_material
+        test_material_3 = nmm.Material("Li4SiO4", packing_fraction=0.5).openmc_material
 
-        assert test_material_3.density == pytest.approx(
-            test_material_1.density * 0.5)
+        assert test_material_3.density == pytest.approx(test_material_1.density * 0.5)
 
-        test_material_4 = nmm.Material(
-            "Li4SiO4", packing_fraction=0.75).openmc_material
+        test_material_4 = nmm.Material("Li4SiO4", packing_fraction=0.75).openmc_material
 
-        assert test_material_4.density == pytest.approx(
-            test_material_1.density * 0.75)
+        assert test_material_4.density == pytest.approx(test_material_1.density * 0.75)
 
     def test_packing_fraction_for_multimaterial_function(self):
 
@@ -279,8 +274,7 @@ class test_object_properties(unittest.TestCase):
             fracs=[0.5, 0.5],
         ).openmc_material
 
-        assert test_material_7.density == pytest.approx(
-            test_material_5.density * 0.5)
+        assert test_material_7.density == pytest.approx(test_material_5.density * 0.5)
 
     def test_packing_fraction_of_a_multimaterial(self):
 
@@ -341,8 +335,7 @@ class test_object_properties(unittest.TestCase):
             percent_type="vo",
         )
 
-        assert test_material_10.density == pytest.approx(
-            test_material_8.density * 0.5)
+        assert test_material_10.density == pytest.approx(test_material_8.density * 0.5)
 
     def test_multimaterial_vs_mix_materials(self):
 

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -27,6 +27,7 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 import pytest
 import unittest
 import json
+import warnings
 
 import neutronics_material_maker as nmm
 
@@ -432,3 +433,49 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["fracs"] == [0.3, 0.7]
         assert test_material_in_json_form["percent_type"] == "vo"
         assert test_material_in_json_form["packing_fraction"] == 1.0
+
+    def test_incorrect_settings(self):
+
+        def too_large_fracs():
+            """checks a ValueError is raised when the fracs are above 1"""
+
+            nmm.MultiMaterial(
+                "test_material",
+                materials=[
+                    nmm.Material("tungsten", packing_fraction=0.6),
+                    nmm.Material("eurofer", packing_fraction=0.8),
+                ],
+                fracs=[0.3, 0.75],
+            )
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            too_large_fracs()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "warning sum of MutliMaterials do not sum to 1." in str(w[-1].message)
+
+        def too_small_fracs():
+            """checks a ValueError is raised when the fracs are above 1"""
+
+            nmm.MultiMaterial(
+                "test_material",
+                materials=[
+                    nmm.Material("tungsten", packing_fraction=0.6),
+                    nmm.Material("eurofer", packing_fraction=0.8),
+                ],
+                fracs=[0.3, 0.65],
+            )
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            too_small_fracs()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "warning sum of MutliMaterials do not sum to 1." in str(w[-1].message)


### PR DESCRIPTION
This PR allows limited use of the neutronics_material_maker without having openmc installed

Naturally you can actually make openmc_materials but you can now import the code and perform some operations on the neutronics_material_maker objects

