### PR TITLE
changed id to material_id

### DIFF
--- a/neutronics_material_maker/data/breeder_materials.json
+++ b/neutronics_material_maker/data/breeder_materials.json
@@ -1,6 +1,6 @@
 {
     "Li": {
-        "elements": "Li",
+        "chemical_equation": "Li",
         "density_equation": "0.515 - 1.01e-4 * (temperature_in_C - 200)",
         "density_unit": "g/cm3",
         "reference": "http://aries.ucsd.edu/LIB/PROPS/PANOS/li.html",
@@ -10,7 +10,7 @@
         "enrichment_type":"ao"
     },
     "Li4SiO4": {
-        "elements": "Li4SiO4",
+        "chemical_equation": "Li4SiO4",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.17162883501e-21,
         "density_unit":"g/cm3",
@@ -22,7 +22,7 @@
         "enrichment_type":"ao"
     },
     "Li2SiO3": {
-        "elements": "Li2SiO3",
+        "chemical_equation": "Li2SiO3",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.12255616623e-21,
         "density_unit":"g/cm3",
@@ -34,7 +34,7 @@
         "enrichment_type":"ao"
     },
     "Li2ZrO3": {
-        "elements": "Li2ZrO3",
+        "chemical_equation": "Li2ZrO3",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.12610426777e-21,
         "density_unit":"g/cm3",
@@ -46,7 +46,7 @@
         "enrichment_type":"ao"
     },
     "Li2TiO3": {
-        "elements": "Li2TiO3",
+        "chemical_equation": "Li2TiO3",
         "atoms_per_unit_cell": 4,
         "volume_of_unit_cell_cm3": 0.21849596020e-21,
         "density_unit":"g/cm3",

--- a/neutronics_material_maker/data/coolant_materials.json
+++ b/neutronics_material_maker/data/coolant_materials.json
@@ -8,7 +8,8 @@
         "pressure_dependant": true,
         "percent_type": "ao"
     },
-    "H2O": {"elements": "H2O",
+    "H2O": {
+        "chemical_equation": "H2O",
         "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'Water')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
@@ -25,7 +26,8 @@
         "density_unit": "g/cm3",
         "percent_type": "ao"
     },
-    "CO2": {"elements": "CO2",
+    "CO2": {
+        "chemical_equation": "CO2",
         "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'CO2')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
@@ -33,7 +35,8 @@
         "pressure_dependant": true,
         "percent_type": "ao"
     },
-    "nitrogen": {"elements": "N",
+    "nitrogen": {
+        "chemical_equation": "N",
         "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'nitrogen')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
@@ -41,7 +44,8 @@
         "pressure_dependant": true,
         "percent_type": "ao"
     },
-    "argon": {"elements": "Ar",
+    "argon": {
+        "chemical_equation": "Ar",
         "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'argon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
@@ -49,7 +53,8 @@
         "pressure_dependant": true,
         "percent_type": "ao"
     },
-    "xenon": {"elements": "Xe",
+    "xenon": {
+        "chemical_equation": "Xe",
         "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'xenon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",

--- a/neutronics_material_maker/data/magnet_materials.json
+++ b/neutronics_material_maker/data/magnet_materials.json
@@ -1,6 +1,6 @@
 {
     "Nb3Sn": {
-        "elements": "Nb3Sn",
+        "chemical_equation": "Nb3Sn",
         "density": 8.69,
         "density_unit": "g/cm3",
         "percent_type": "ao"

--- a/neutronics_material_maker/data/multiplier_and_breeder_materials.json
+++ b/neutronics_material_maker/data/multiplier_and_breeder_materials.json
@@ -1,6 +1,6 @@
 {
     "Pb842Li158": {
-        "elements": "Pb842Li158",
+        "chemical_equation": "Pb842Li158",
         "density_equation": "99.90*(0.1-16.8e-6*temperature_in_C)",
         "density_unit": "g/cm3",
         "reference": "density equation valid for in the range 240-350 C. source http://aries.ucsd.edu/LIB/PROPS/PANOS/lipb.html",
@@ -20,7 +20,7 @@
         "enrichment_type":"ao"
     },
     "Li8PbO6": {
-        "elements": "Li8PbO6",
+        "chemical_equation": "Li8PbO6",
         "atoms_per_unit_cell": 1,
         "volume_of_unit_cell_cm3": 0.14400485967e-21,
         "density_unit":"g/cm3",
@@ -32,7 +32,7 @@
         "enrichment_type":"ao"
     },
     "FLiBe": {
-        "elements": "F2Li2BeF2",
+        "chemical_equation": "F2Li2BeF2",
         "density_equation": "2.214 - 4.2e-4 * temperature_in_C",
         "density_unit": "g/cm3",
         "reference": "source http://aries.ucsd.edu/LIB/MEETINGS/0103-TRANSMUT/gohar/Gohar-present.pdf",

--- a/neutronics_material_maker/data/multiplier_materials.json
+++ b/neutronics_material_maker/data/multiplier_materials.json
@@ -1,13 +1,13 @@
 {
     "Pb": {
-        "elements": "Pb",
+        "chemical_equation": "Pb",
         "density": "10.678 - 13.174e-4 * (temperature_in_K-600.6)",
         "density_unit": "g/cm3",
         "reference": "https://www.sciencedirect.com/science/article/abs/pii/0022190261802261",
         "percent_type": "ao"
     },
     "Be": {
-        "elements": "Be",
+        "chemical_equation": "Be",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.01587959994e-21,
         "density_unit": "g/cm3",
@@ -17,7 +17,7 @@
         "percent_type": "ao"
     },
     "Be12Ti": {
-        "elements": "Be12Ti",
+        "chemical_equation": "Be12Ti",
         "atoms_per_unit_cell": 1,
         "volume_of_unit_cell_cm3": 0.11350517285e-21,
         "enrichable": false,
@@ -27,7 +27,7 @@
         "percent_type": "ao"
     },
     "Ba5Pb3": {
-        "elements": "Ba5Pb3",
+        "chemical_equation": "Ba5Pb3",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.74343377212e-21,
         "density_unit": "g/cm3",
@@ -37,7 +37,7 @@
         "percent_type": "ao"
     },
     "Nd5Pb4": {
-        "elements": "Nd5Pb4",
+        "chemical_equation": "Nd5Pb4",
         "atoms_per_unit_cell": 4,
         "volume_of_unit_cell_cm3": 1.17174024048e-21,
         "density_unit": "g/cm3",
@@ -47,7 +47,7 @@
         "percent_type": "ao"
     },
     "Zr5Pb3": {
-        "elements": "Zr5Pb3",
+        "chemical_equation": "Zr5Pb3",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.43511266920e-21,
         "density_unit": "g/cm3",
@@ -57,7 +57,7 @@
         "percent_type": "ao"
     },
     "Zr5Pb4": {
-        "elements": "Zr5Pb4",
+        "chemical_equation": "Zr5Pb4",
         "atoms_per_unit_cell": 2,
         "volume_of_unit_cell_cm3": 0.40435e-21,
         "density_unit": "g/cm3",

--- a/neutronics_material_maker/data/structural_materials.json
+++ b/neutronics_material_maker/data/structural_materials.json
@@ -1,16 +1,18 @@
 {
-    "WC": {"elements": "WC",
+    "WC": {
+        "chemical_equation": "WC",
         "density": 18.0,
         "density_unit": "g/cm3",
         "percent_type": "ao"
     },
-    "WB": {"elements": "WB",
+    "WB": {
+        "chemical_equation": "WB",
         "density": 15.3,
         "density_unit": "g/cm3",
         "percent_type": "ao"
     },
     "SiC": {
-        "elements": "SiC",
+        "chemical_equation": "SiC",
         "density": 3,
         "density_unit": "g/cm3",
         "percent_type": "ao"
@@ -268,7 +270,7 @@
         "percent_type": "ao"
     },
     "B4C":{
-        "elements": "B4C",
+        "chemical_equation": "B4C",
         "density": 2.52,
         "density_unit": "g/cm3",
         "percent_type": "ao"

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -210,7 +210,7 @@ class Material:
         if chemical_equation is not None and elements is not None:
             raise ValueError(
                 "Material.chemical_equation and Material.elements can not both be set"
-            )            
+            )
 
         if self.material_name in material_dict.keys():
 
@@ -552,7 +552,8 @@ class Material:
         else:
             name = self.material_tag
         if self.material_id is not None:
-            openmc_material = openmc.Material(material_id=self.material_id, name=name)
+            openmc_material = openmc.Material(
+                material_id=self.material_id, name=name)
         else:
             openmc_material = openmc.Material(name=name)
 
@@ -563,11 +564,11 @@ class Material:
         elif self.elements is not None:
 
             openmc_material = self._add_elements_from_dict(openmc_material)
-        
+
         elif self.chemical_equation is not None:
 
             openmc_material = self._add_elements_from_equation(openmc_material)
-            
+
         openmc_material = self._add_density(openmc_material)
 
         return openmc_material

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -116,13 +116,12 @@ class Material:
             These tend to be liquids and gases used for coolants and even
             liquids such as lithium-lead and FLiBe that are used as breeder
             materials.
-        pressure_in_Pa (float): The temperature of the material in degrees
-            C. Temperature impacts the density of some materials in the
+        pressure_in_Pa (float): The pressure of the material in Pascals
+            Pressure impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
-            temperature have density equations that depend on temperature.
-            These tend to be liquids and gases used for coolants and even
-            liquids such as lithium-lead and FLiBe that are used as breeder
-            materials.
+            pressure have density equations that depend on pressure.
+            These tend to be liquids and gases used for coolants such as
+            H2O and CO2.
         zaid_suffix (str): The nuclear library to apply to the zaid, for
             example ".31c", this is used in MCNP and Serpent material cards.
         material_id (int): the id number or mat number used in the MCNP material card
@@ -202,17 +201,11 @@ class Material:
         self.volume_in_cm3 = volume_in_cm3
 
         # derived values
-        self.enrichment_element = None
-        self.density_packed = None
-
         self.openmc_material = None
         self.serpent_material = None
         self.mcnp_material = None
         self.fispact_material = None
-
         self.list_of_fractions = None
-        self.element_numbers = None
-        self.element_symbols = None
 
         if chemical_equation is not None and elements is not None:
             raise ValueError(

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -60,7 +60,7 @@ class MultiMaterial:
             to 1/void fraction
         zaid_suffix (str): The nuclear library to apply to the zaid, for example
             ".31c", this is used in MCNP and Serpent material cards.
-        id (int): The id number or mat number used in the MCNP material card
+        material_id (int): The id number or mat number used in the MCNP material card
         volume_in_cm3 (float): The volume of the material in cm3, used when creating
             fispact material cards
 
@@ -77,7 +77,7 @@ class MultiMaterial:
         percent_type="vo",
         packing_fraction=1.0,
         zaid_suffix=None,
-        id=None,
+        material_id=None,
         volume_in_cm3=None,
     ):
         self.material_tag = material_tag
@@ -86,7 +86,7 @@ class MultiMaterial:
         self.percent_type = percent_type
         self.packing_fraction = packing_fraction
         self.zaid_suffix = zaid_suffix
-        self.id = id
+        self.material_id = material_id
         self.volume_in_cm3 = volume_in_cm3
 
         # derived values
@@ -221,6 +221,7 @@ class MultiMaterial:
                     "pressure_in_Pa": material.pressure_in_Pa,
                     "packing_fraction": material.packing_fraction,
                     "elements": material.elements,
+                    "chemical_equation": material.chemical_equation,
                     "isotopes": material.isotopes,
                     "density": material.density,
                     "density_equation": material.density_equation,
@@ -232,6 +233,9 @@ class MultiMaterial:
                     "enrichment_target": material.enrichment_target,
                     "enrichment_type": material.enrichment_type,
                     "reference": material.reference,
+                    "zaid_suffix": material.zaid_suffix,
+                    "material_id": material.material_id,
+                    "volume_in_cm3": material.volume_in_cm3,
                 })
 
         jsonified_object = {
@@ -240,6 +244,9 @@ class MultiMaterial:
             "fracs": self.fracs,
             "percent_type": self.percent_type,
             "packing_fraction": self.packing_fraction,
+            "zaid_suffix": self.zaid_suffix,
+            "material_id": self.material_id,
+            "volume_in_cm3": self.volume_in_cm3,
         }
 
         return jsonified_object

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -75,9 +75,9 @@ def make_serpent_material(mat):
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
 
-    if mat.id is None:
+    if mat.material_id is None:
         raise ValueError(
-            "Material.id needs setting before mcnp_material can be made"
+            "Material.material_id needs setting before mcnp_material can be made"
         )
 
     if mat.material_tag is None:
@@ -100,7 +100,7 @@ def make_mcnp_material(mat):
     for i, isotope in enumerate(mat.openmc_material.nuclides):
 
         if i == 0:
-            start = "M" + str(mat.id) + " "
+            start = "M" + str(mat.material_id) + " "
         else:
             start = "     "
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -64,14 +64,14 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_suffix(self):
         test_material1 = nmm.Material(
-            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c", id=27
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".21c", material_id=27
         )
         mcnp_material1 = test_material1.mcnp_material
         test_material2 = nmm.Material(
-            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c", id=27
+            "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c", material_id=27
         )
         mcnp_material2 = test_material2.mcnp_material
-        test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", id=27)
+        test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", material_id=27)
         mcnp_material3 = test_material3.mcnp_material
 
         assert len(mcnp_material3) < len(mcnp_material2)
@@ -80,7 +80,7 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_lines(self):
         test_material = nmm.Material(
-            "Nb3Sn", material_tag="test", density=3, zaid_suffix=".30c", id=27
+            "Nb3Sn", material_tag="test", density=3, zaid_suffix=".30c", material_id=27
         )
         mcnp_material = test_material.mcnp_material
         line_by_line_material = mcnp_material.split("\n")
@@ -106,11 +106,11 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
-            elements="Nb3Sn",
+            chemical_equation="Nb3Sn",
             material_tag="test2",
             density=3.2,
             density_unit='g/cm3',
-            id=1,
+            material_id=1,
             percent_type='wo')
         mcnp_material = test_material.mcnp_material
         line_by_line_material = mcnp_material.split("\n")
@@ -135,11 +135,11 @@ class test_object_properties(unittest.TestCase):
 
     def test_serpent_material_lines_contain_underscore(self):
         test_material = nmm.Material(
-            elements="Nb3Sn",
+            chemical_equation="Nb3Sn",
             material_tag="test2",
             density=3.2,
             density_unit='g/cm3',
-            id=1,
+            material_id=1,
             percent_type='wo')
         serpent_material = test_material.serpent_material
         line_by_line_material = serpent_material.split("\n")
@@ -199,7 +199,7 @@ class test_object_properties(unittest.TestCase):
     def test_adding_one_material_AddMaterialFromFile(self):
         test_material_1 = {
             "WC2": {
-                "elements": "WC",
+                "chemical_equation": "WC",
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
@@ -219,13 +219,13 @@ class test_object_properties(unittest.TestCase):
     def test_adding_two_material_AddMaterialFromFile(self):
         test_material_1 = {
             "WC3": {
-                "elements": "WC",
+                "chemical_equation": "WC",
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
             },
             "WB2": {
-                "elements": "WB",
+                "chemical_equation": "WB",
                 "density": 15.3,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
@@ -246,7 +246,7 @@ class test_object_properties(unittest.TestCase):
     def test_replacing_material_using_AddMaterialFromFile(self):
         test_material_1 = {
             "Li4SiO4": {
-                "elements": "WC",
+                "chemical_equation": "WC",
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
@@ -268,7 +268,7 @@ class test_object_properties(unittest.TestCase):
 
         test_material_1 = {
             "Li4SiO42": {
-                "elements": "WC",
+                "chemical_equation": "WC",
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
@@ -282,7 +282,7 @@ class test_object_properties(unittest.TestCase):
 
         test_material_2 = {
             "Li4SiO43": {
-                "elements": "WC",
+                "chemical_equation": "WC",
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
@@ -301,28 +301,6 @@ class test_object_properties(unittest.TestCase):
         assert "Li4SiO42" in nmm.AvailableMaterials().keys()
         assert "Li4SiO43" in nmm.AvailableMaterials().keys()
 
-    def test_material_creation_from_chemical_formula(self):
-
-        lead_fraction = 3
-        lithium_fraction = 7
-
-        lithium_lead_elements = "Li" + \
-            str(lithium_fraction) + "Pb" + str(lead_fraction)
-        test_material = nmm.Material(
-            "lithium-lead",
-            elements=lithium_lead_elements,
-            temperature_in_C=450)
-        nucs = test_material.openmc_material.nuclides
-        pb_atom_count = 0
-        li_atom_count = 0
-        for entry in nucs:
-            if entry[0].startswith("Pb"):
-                pb_atom_count = pb_atom_count + entry[1]
-            if entry[0].startswith("Li"):
-                li_atom_count = li_atom_count + entry[1]
-        assert pb_atom_count == lead_fraction
-        assert li_atom_count == lithium_fraction
-
     def test_material_creation_from_chemical_formula_with_enrichment(self):
 
         lead_fraction = 3
@@ -336,7 +314,7 @@ class test_object_properties(unittest.TestCase):
             enrichment=enrichment,
             enrichment_target="Li6",
             enrichment_type="ao",
-            elements=lithium_lead_elements,
+            chemical_equation=lithium_lead_elements,
             temperature_in_C=450,
         )
         nucs = test_material.openmc_material.nuclides
@@ -384,7 +362,7 @@ class test_object_properties(unittest.TestCase):
             enrichment=enrichment,
             enrichment_target="Li6",
             enrichment_type="ao",
-            elements=lithium_lead_elements,
+            chemical_equation=lithium_lead_elements,
             temperature_in_C=450,
         )
         nucs = test_material.openmc_material.nuclides
@@ -497,7 +475,7 @@ class test_object_properties(unittest.TestCase):
             str(lithium_fraction) + "Pb" + str(lead_fraction)
         test_material = nmm.Material(
             "lithium-lead",
-            elements=lithium_lead_elements,
+            chemical_equation=lithium_lead_elements,
             temperature_in_C=450)
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
@@ -581,7 +559,7 @@ class test_object_properties(unittest.TestCase):
         assert "density" in test_material_in_json_form.keys()
         assert "density_equation" in test_material_in_json_form.keys()
         assert "density_unit" in test_material_in_json_form.keys()
-        assert "elements" in test_material_in_json_form.keys()
+        assert "chemical_equation" in test_material_in_json_form.keys()
         assert "enrichment" in test_material_in_json_form.keys()
         assert "enrichment_target" in test_material_in_json_form.keys()
         assert "enrichment_type" in test_material_in_json_form.keys()

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -71,7 +71,8 @@ class test_object_properties(unittest.TestCase):
             "Nb3Sn", material_tag="Nb3Sn", zaid_suffix=".30c", material_id=27
         )
         mcnp_material2 = test_material2.mcnp_material
-        test_material3 = nmm.Material("Nb3Sn", material_tag="Nb3Sn", material_id=27)
+        test_material3 = nmm.Material(
+            "Nb3Sn", material_tag="Nb3Sn", material_id=27)
         mcnp_material3 = test_material3.mcnp_material
 
         assert len(mcnp_material3) < len(mcnp_material2)
@@ -80,8 +81,11 @@ class test_object_properties(unittest.TestCase):
 
     def test_mcnp_material_lines(self):
         test_material = nmm.Material(
-            "Nb3Sn", material_tag="test", density=3, zaid_suffix=".30c", material_id=27
-        )
+            "Nb3Sn",
+            material_tag="test",
+            density=3,
+            zaid_suffix=".30c",
+            material_id=27)
         mcnp_material = test_material.mcnp_material
         line_by_line_material = mcnp_material.split("\n")
 

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -67,7 +67,7 @@ class test_object_properties(unittest.TestCase):
             materials=[nmm.Material("Li4SiO4"), nmm.Material("Be12Ti")],
             fracs=[0.50, 0.50],
             percent_type="vo",
-            id=2,
+            material_id=2,
         )
 
         assert len(test_material.mcnp_material) > 100


### PR DESCRIPTION
This PR adds a new feature and tidies up a few parts. 

- material_id instead of id as this is a reserved word in python
- use of chemical_equation instead of elements for materials with elements that are strings (e.g. "H2O", "CO", "Li4SiO4"). The use of chemical_equation make for better code structure and makes testing easier.


