### PR TITLE
removed default of mat_id=1

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -149,7 +149,7 @@ class Material:
         enrichment_type=None,
         reference=None,
         zaid_suffix=None,
-        material_id=1,
+        material_id=None,
         volume_in_cm3=None,
     ):
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.3",
+    version="0.1.4",
     summary="Package for making material cards for OpenMC",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",


### PR DESCRIPTION
mat id having a default of 1 was meaning all the openmc materials had the same material id number. So this PR sets is back to None