### PR TITLE
Mcnp material formatting

### DIFF
--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -44,6 +44,11 @@ def make_fispact_material(mat):
 
 def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
+    
+    # decimal places to print
+    dp = 6
+    
+    
     if mat.material_tag is None:
         name = mat.material_name
     else:
@@ -64,11 +69,11 @@ def make_serpent_material(mat):
         elif isotope[2] == "wo":
             prefix = " -"
         mat_card.append(
-            "     "
+            "      "
             + isotope_to_zaid(isotope[0])
             + zaid_suffix
             + prefix
-            + str(isotope[1])
+            + f'{isotope[1]:{dp}e}'
         )
 
     return "\n".join(mat_card)
@@ -76,6 +81,9 @@ def make_serpent_material(mat):
 
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
+    
+    # Number of decimal places to print
+    dp = 8
 
     if mat.material_id is None:
         raise ValueError(
@@ -96,15 +104,15 @@ def make_mcnp_material(mat):
         "c     "
         + name
         + " density "
-        + str(mat.openmc_material.get_mass_density())
+        + f'{mat.openmc_material.get_mass_density():{dp}e}'
         + " g/cm3"
     ]
     for i, isotope in enumerate(mat.openmc_material.nuclides):
 
         if i == 0:
-            start = "M" + str(mat.material_id) + " "
+            start = f'M{mat.material_id: <5}'
         else:
-            start = "     "
+            start = "      "
 
         if isotope[2] == "ao":
             prefix = "  "
@@ -112,7 +120,7 @@ def make_mcnp_material(mat):
             prefix = " -"
 
         rest = isotope_to_zaid(isotope[0]) + \
-            zaid_suffix + prefix + str(isotope[1])
+            zaid_suffix + prefix + f'{isotope[1]:{dp}e}'
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -44,11 +44,10 @@ def make_fispact_material(mat):
 
 def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
-    
+
     # decimal places to print
     dp = 6
-    
-    
+
     if mat.material_tag is None:
         name = mat.material_name
     else:
@@ -81,7 +80,7 @@ def make_serpent_material(mat):
 
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
-    
+
     # Number of decimal places to print
     dp = 8
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.5",
+    version="0.1.6",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -126,18 +126,18 @@ class test_object_properties(unittest.TestCase):
         assert float(line_by_line_material[0].split()[3]) == pytest.approx(3)
         assert line_by_line_material[0].split()[4] == "g/cm3"
 
-        assert line_by_line_material[1] == "M27 041093.30c  0.75"
+        assert line_by_line_material[1] == "M27   041093.30c  7.500000e-01"
 
-        assert "     050112.30c  0.002425" in line_by_line_material
-        assert "     050114.30c  0.00165" in line_by_line_material
-        assert "     050115.30c  0.00085" in line_by_line_material
-        assert "     050116.30c  0.03635" in line_by_line_material
-        assert "     050117.30c  0.0192" in line_by_line_material
-        assert "     050118.30c  0.06055" in line_by_line_material
-        assert "     050119.30c  0.021475" in line_by_line_material
-        assert "     050120.30c  0.08145" in line_by_line_material
-        assert "     050122.30c  0.011575" in line_by_line_material
-        assert "     050124.30c  0.014475" in line_by_line_material
+        assert "      050120.30c  8.145000e-02" in line_by_line_material
+        assert "      050119.30c  2.147500e-02" in line_by_line_material
+        assert "      050115.30c  8.500000e-04" in line_by_line_material
+        assert "      050112.30c  2.425000e-03" in line_by_line_material
+        assert "      050118.30c  6.055000e-02" in line_by_line_material
+        assert "      050122.30c  1.157500e-02" in line_by_line_material
+        assert "      050124.30c  1.447500e-02" in line_by_line_material
+        assert "      050114.30c  1.650000e-03" in line_by_line_material
+        assert "      050117.30c  1.920000e-02" in line_by_line_material
+        assert "      050116.30c  3.635000e-02" in line_by_line_material
 
     def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
@@ -221,17 +221,17 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[0].split()[0] == "mat"
         assert line_by_line_material[0].split()[1] == "test"
         assert float(line_by_line_material[0].split()[2]) == pytest.approx(3)
-        assert "     041093.30c  0.75" in line_by_line_material
-        assert "     050112.30c  0.002425" in line_by_line_material
-        assert "     050114.30c  0.00165" in line_by_line_material
-        assert "     050115.30c  0.00085" in line_by_line_material
-        assert "     050116.30c  0.03635" in line_by_line_material
-        assert "     050117.30c  0.0192" in line_by_line_material
-        assert "     050118.30c  0.06055" in line_by_line_material
-        assert "     050119.30c  0.021475" in line_by_line_material
-        assert "     050120.30c  0.08145" in line_by_line_material
-        assert "     050122.30c  0.011575" in line_by_line_material
-        assert "     050124.30c  0.014475" in line_by_line_material
+        assert "      041093.30c  7.500000e-01" in line_by_line_material
+        assert "      050120.30c  8.145000e-02" in line_by_line_material
+        assert "      050119.30c  2.147500e-02" in line_by_line_material
+        assert "      050115.30c  8.500000e-04" in line_by_line_material
+        assert "      050112.30c  2.425000e-03" in line_by_line_material
+        assert "      050118.30c  6.055000e-02" in line_by_line_material
+        assert "      050122.30c  1.157500e-02" in line_by_line_material
+        assert "      050124.30c  1.447500e-02" in line_by_line_material
+        assert "      050114.30c  1.650000e-03" in line_by_line_material
+        assert "      050117.30c  1.920000e-02" in line_by_line_material
+        assert "      050116.30c  3.635000e-02" in line_by_line_material
 
     def test_material_creation_from_chemical_formula_with_enrichment(self):
 


### PR DESCRIPTION
Minor changes to output formatting for MCNP and Serpent.

Previously floats were left to default formatting, which meant floats were printed in a variety of ways and lengths, which may cause problems with the MCNP line limit of 80 characters. 

Unit tests undated to accommodate these changes. 