### PR TITLE
Mcnp material formatting

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -102,6 +102,8 @@ class Material:
         zaid_suffix (str): The nuclear library to apply to the zaid, for
             example ".31c", this is used in MCNP and Serpent material cards.
         material_id (int): the id number or mat number used in the MCNP material card
+        decimal_places (int): The number of decimal places to use in MCNP and
+            Seprent material cards when they are printed out (default of 8).
         volume_in_cm3 (float): The volume of the material in cm3, used when
             creating fispact material cards
         elements (dict): A dictionary of keys and values with the element symbol
@@ -154,6 +156,7 @@ class Material:
         reference=None,
         zaid_suffix=None,
         material_id=None,
+        decimal_places=8,
         volume_in_cm3=None,
     ):
 
@@ -178,6 +181,7 @@ class Material:
         self.reference = reference
         self.zaid_suffix = zaid_suffix
         self.material_id = material_id
+        self.decimal_places = decimal_places
         self.volume_in_cm3 = volume_in_cm3
 
         # derived values
@@ -875,6 +879,7 @@ class Material:
             "reference": self.reference,
             "zaid_suffix": self.zaid_suffix,
             "material_id": self.material_id,
+            "decimal_places": self.decimal_places,
             "volume_in_cm3": self.volume_in_cm3,
         }
 

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -60,6 +60,8 @@ class MultiMaterial:
         zaid_suffix (str): The nuclear library to apply to the zaid, for example
             ".31c", this is used in MCNP and Serpent material cards.
         material_id (int): The id number or mat number used in the MCNP material card
+        decimal_places (int): The number of decimal places to use in MCNP and
+            Seprent material cards when they are printed out (default of 8).
         volume_in_cm3 (float): The volume of the material in cm3, used when creating
             fispact material cards
 
@@ -77,6 +79,7 @@ class MultiMaterial:
         packing_fraction=1.0,
         zaid_suffix=None,
         material_id=None,
+        decimal_places=8,
         volume_in_cm3=None,
     ):
         self.material_tag = material_tag
@@ -86,6 +89,7 @@ class MultiMaterial:
         self.packing_fraction = packing_fraction
         self.zaid_suffix = zaid_suffix
         self.material_id = material_id
+        self.decimal_places = decimal_places
         self.volume_in_cm3 = volume_in_cm3
 
         # derived values
@@ -234,6 +238,7 @@ class MultiMaterial:
                     "reference": material.reference,
                     "zaid_suffix": material.zaid_suffix,
                     "material_id": material.material_id,
+                    "decimal_places": material.decimal_places,
                     "volume_in_cm3": material.volume_in_cm3,
                 })
 
@@ -245,6 +250,7 @@ class MultiMaterial:
             "packing_fraction": self.packing_fraction,
             "zaid_suffix": self.zaid_suffix,
             "material_id": self.material_id,
+            "decimal_places": self.decimal_places,
             "volume_in_cm3": self.volume_in_cm3,
         }
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -45,9 +45,6 @@ def make_fispact_material(mat):
 def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
 
-    # decimal places to print
-    decimal_places = 6
-
     if mat.material_tag is None:
         name = mat.material_name
     else:
@@ -72,7 +69,7 @@ def make_serpent_material(mat):
             + isotope_to_zaid(isotope[0])
             + zaid_suffix
             + prefix
-            + f'{isotope[1]:{decimal_places}e}'
+            + f'{isotope[1]:.{mat.decimal_places}e}'
         )
 
     return "\n".join(mat_card)
@@ -80,9 +77,6 @@ def make_serpent_material(mat):
 
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
-
-    # Number of decimal places to print
-    decimal_places = 8
 
     if mat.material_id is None:
         raise ValueError(
@@ -103,7 +97,7 @@ def make_mcnp_material(mat):
         "c     "
         + name
         + " density "
-        + f'{mat.openmc_material.get_mass_density():{decimal_places}e}'
+        + f'{mat.openmc_material.get_mass_density():.{mat.decimal_places}e}'
         + " g/cm3"
     ]
     for i, isotope in enumerate(mat.openmc_material.nuclides):
@@ -119,7 +113,7 @@ def make_mcnp_material(mat):
             prefix = " -"
 
         rest = isotope_to_zaid(isotope[0]) + \
-            zaid_suffix + prefix + f'{isotope[1]:{decimal_places}e}'
+            zaid_suffix + prefix + f'{isotope[1]:.{mat.decimal_places}e}'
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -44,6 +44,11 @@ def make_fispact_material(mat):
 
 def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
+    
+    # decimal places to print
+    dp = 6
+    
+    
     if mat.material_tag is None:
         name = mat.material_name
     else:
@@ -64,11 +69,11 @@ def make_serpent_material(mat):
         elif isotope[2] == "wo":
             prefix = " -"
         mat_card.append(
-            "     "
+            "      "
             + isotope_to_zaid(isotope[0])
             + zaid_suffix
             + prefix
-            + str(isotope[1])
+            + f'{isotope[1]:{dp}e}'
         )
 
     return "\n".join(mat_card)
@@ -76,6 +81,9 @@ def make_serpent_material(mat):
 
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
+    
+    # Number of decimal places to print
+    dp = 8
 
     if mat.material_id is None:
         raise ValueError(
@@ -96,15 +104,15 @@ def make_mcnp_material(mat):
         "c     "
         + name
         + " density "
-        + str(mat.openmc_material.get_mass_density())
+        + f'{mat.openmc_material.get_mass_density():{dp}e}'
         + " g/cm3"
     ]
     for i, isotope in enumerate(mat.openmc_material.nuclides):
 
         if i == 0:
-            start = "M" + str(mat.material_id) + " "
+            start = f'M{mat.material_id: <5}'
         else:
-            start = "     "
+            start = "      "
 
         if isotope[2] == "ao":
             prefix = "  "
@@ -112,7 +120,7 @@ def make_mcnp_material(mat):
             prefix = " -"
 
         rest = isotope_to_zaid(isotope[0]) + \
-            zaid_suffix + prefix + str(isotope[1])
+            zaid_suffix + prefix + f'{isotope[1]:{dp}e}'
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -46,7 +46,7 @@ def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
 
     # decimal places to print
-    dp = 6
+    decimal_places = 6
 
     if mat.material_tag is None:
         name = mat.material_name
@@ -72,7 +72,7 @@ def make_serpent_material(mat):
             + isotope_to_zaid(isotope[0])
             + zaid_suffix
             + prefix
-            + f'{isotope[1]:{dp}e}'
+            + f'{isotope[1]:{decimal_places}e}'
         )
 
     return "\n".join(mat_card)
@@ -82,7 +82,7 @@ def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
 
     # Number of decimal places to print
-    dp = 8
+    decimal_places = 8
 
     if mat.material_id is None:
         raise ValueError(
@@ -103,7 +103,7 @@ def make_mcnp_material(mat):
         "c     "
         + name
         + " density "
-        + f'{mat.openmc_material.get_mass_density():{dp}e}'
+        + f'{mat.openmc_material.get_mass_density():{decimal_places}e}'
         + " g/cm3"
     ]
     for i, isotope in enumerate(mat.openmc_material.nuclides):
@@ -119,7 +119,7 @@ def make_mcnp_material(mat):
             prefix = " -"
 
         rest = isotope_to_zaid(isotope[0]) + \
-            zaid_suffix + prefix + f'{isotope[1]:{dp}e}'
+            zaid_suffix + prefix + f'{isotope[1]:{decimal_places}e}'
 
         mat_card.append(start + rest)
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -44,11 +44,10 @@ def make_fispact_material(mat):
 
 def make_serpent_material(mat):
     """Returns the material in a string compatable with Serpent II"""
-    
+
     # decimal places to print
     dp = 6
-    
-    
+
     if mat.material_tag is None:
         name = mat.material_name
     else:
@@ -81,7 +80,7 @@ def make_serpent_material(mat):
 
 def make_mcnp_material(mat):
     """Returns the material in a string compatable with MCNP6"""
-    
+
     # Number of decimal places to print
     dp = 8
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.5",
+    version="0.1.6",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -140,7 +140,6 @@ class test_object_properties(unittest.TestCase):
         assert "      050117.30c  1.920000e-02" in line_by_line_material
         assert "      050116.30c  3.635000e-02" in line_by_line_material
 
-
     def test_mcnp_material_lines_with_decimal_places(self):
         test_material = nmm.Material(
             "Nb3Sn",
@@ -278,7 +277,8 @@ class test_object_properties(unittest.TestCase):
         assert len(line_by_line_material) == 12
         assert line_by_line_material[0].split()[0] == "mat"
         assert line_by_line_material[0].split()[1] == "test"
-        assert float(line_by_line_material[0].split()[2]) == pytest.approx(3.3333)
+        assert float(line_by_line_material[0].split()[
+                     2]) == pytest.approx(3.3333)
         assert "      041093.30c  7.5000e-01" in line_by_line_material
         assert "      050120.30c  8.1450e-02" in line_by_line_material
         assert "      050119.30c  2.1475e-02" in line_by_line_material

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -115,6 +115,7 @@ class test_object_properties(unittest.TestCase):
             material_tag="test",
             density=3,
             zaid_suffix=".30c",
+            decimal_places=6,
             material_id=27)
         line_by_line_material = test_material.mcnp_material.split("\n")
 
@@ -138,6 +139,38 @@ class test_object_properties(unittest.TestCase):
         assert "      050114.30c  1.650000e-03" in line_by_line_material
         assert "      050117.30c  1.920000e-02" in line_by_line_material
         assert "      050116.30c  3.635000e-02" in line_by_line_material
+
+
+    def test_mcnp_material_lines_with_decimal_places(self):
+        test_material = nmm.Material(
+            "Nb3Sn",
+            material_tag="test",
+            density=3,
+            zaid_suffix=".30c",
+            material_id=27,
+            decimal_places=3)
+        line_by_line_material = test_material.mcnp_material.split("\n")
+
+        assert len(line_by_line_material) == 12
+
+        assert line_by_line_material[0].split()[0] == "c"
+        assert line_by_line_material[0].split()[1] == "test"
+        assert line_by_line_material[0].split()[2] == "density"
+        assert float(line_by_line_material[0].split()[3]) == pytest.approx(3)
+        assert line_by_line_material[0].split()[4] == "g/cm3"
+
+        assert line_by_line_material[1] == "M27   041093.30c  7.500e-01"
+
+        assert "      050120.30c  8.145e-02" in line_by_line_material
+        assert "      050119.30c  2.148e-02" in line_by_line_material  # rounded up
+        assert "      050115.30c  8.500e-04" in line_by_line_material
+        assert "      050112.30c  2.425e-03" in line_by_line_material
+        assert "      050118.30c  6.055e-02" in line_by_line_material
+        assert "      050122.30c  1.158e-02" in line_by_line_material  # rounded up
+        assert "      050124.30c  1.448e-02" in line_by_line_material  # rounded up
+        assert "      050114.30c  1.650e-03" in line_by_line_material
+        assert "      050117.30c  1.920e-02" in line_by_line_material
+        assert "      050116.30c  3.635e-02" in line_by_line_material
 
     def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
@@ -221,17 +254,42 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[0].split()[0] == "mat"
         assert line_by_line_material[0].split()[1] == "test"
         assert float(line_by_line_material[0].split()[2]) == pytest.approx(3)
-        assert "      041093.30c  7.500000e-01" in line_by_line_material
-        assert "      050120.30c  8.145000e-02" in line_by_line_material
-        assert "      050119.30c  2.147500e-02" in line_by_line_material
-        assert "      050115.30c  8.500000e-04" in line_by_line_material
-        assert "      050112.30c  2.425000e-03" in line_by_line_material
-        assert "      050118.30c  6.055000e-02" in line_by_line_material
-        assert "      050122.30c  1.157500e-02" in line_by_line_material
-        assert "      050124.30c  1.447500e-02" in line_by_line_material
-        assert "      050114.30c  1.650000e-03" in line_by_line_material
-        assert "      050117.30c  1.920000e-02" in line_by_line_material
-        assert "      050116.30c  3.635000e-02" in line_by_line_material
+        assert "      041093.30c  7.50000000e-01" in line_by_line_material
+        assert "      050120.30c  8.14500000e-02" in line_by_line_material
+        assert "      050119.30c  2.14750000e-02" in line_by_line_material
+        assert "      050115.30c  8.50000000e-04" in line_by_line_material
+        assert "      050112.30c  2.42500000e-03" in line_by_line_material
+        assert "      050118.30c  6.05500000e-02" in line_by_line_material
+        assert "      050122.30c  1.15750000e-02" in line_by_line_material
+        assert "      050124.30c  1.44750000e-02" in line_by_line_material
+        assert "      050114.30c  1.65000000e-03" in line_by_line_material
+        assert "      050117.30c  1.92000000e-02" in line_by_line_material
+        assert "      050116.30c  3.63500000e-02" in line_by_line_material
+
+    def test_serpent_material_lines_with_decimal_places(self):
+        test_material = nmm.Material(
+            "Nb3Sn",
+            material_tag="test",
+            density=3.3333,
+            zaid_suffix=".30c",
+            decimal_places=4)
+        line_by_line_material = test_material.serpent_material.split("\n")
+
+        assert len(line_by_line_material) == 12
+        assert line_by_line_material[0].split()[0] == "mat"
+        assert line_by_line_material[0].split()[1] == "test"
+        assert float(line_by_line_material[0].split()[2]) == pytest.approx(3.3333)
+        assert "      041093.30c  7.5000e-01" in line_by_line_material
+        assert "      050120.30c  8.1450e-02" in line_by_line_material
+        assert "      050119.30c  2.1475e-02" in line_by_line_material
+        assert "      050115.30c  8.5000e-04" in line_by_line_material
+        assert "      050112.30c  2.4250e-03" in line_by_line_material
+        assert "      050118.30c  6.0550e-02" in line_by_line_material
+        assert "      050122.30c  1.1575e-02" in line_by_line_material
+        assert "      050124.30c  1.4475e-02" in line_by_line_material
+        assert "      050114.30c  1.6500e-03" in line_by_line_material
+        assert "      050117.30c  1.9200e-02" in line_by_line_material
+        assert "      050116.30c  3.6350e-02" in line_by_line_material
 
     def test_material_creation_from_chemical_formula_with_enrichment(self):
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -126,18 +126,18 @@ class test_object_properties(unittest.TestCase):
         assert float(line_by_line_material[0].split()[3]) == pytest.approx(3)
         assert line_by_line_material[0].split()[4] == "g/cm3"
 
-        assert line_by_line_material[1] == "M27 041093.30c  0.75"
+        assert line_by_line_material[1] == "M27   041093.30c  7.500000e-01"
 
-        assert "     050112.30c  0.002425" in line_by_line_material
-        assert "     050114.30c  0.00165" in line_by_line_material
-        assert "     050115.30c  0.00085" in line_by_line_material
-        assert "     050116.30c  0.03635" in line_by_line_material
-        assert "     050117.30c  0.0192" in line_by_line_material
-        assert "     050118.30c  0.06055" in line_by_line_material
-        assert "     050119.30c  0.021475" in line_by_line_material
-        assert "     050120.30c  0.08145" in line_by_line_material
-        assert "     050122.30c  0.011575" in line_by_line_material
-        assert "     050124.30c  0.014475" in line_by_line_material
+        assert "      050120.30c  8.145000e-02" in line_by_line_material
+        assert "      050119.30c  2.147500e-02" in line_by_line_material
+        assert "      050115.30c  8.500000e-04" in line_by_line_material
+        assert "      050112.30c  2.425000e-03" in line_by_line_material
+        assert "      050118.30c  6.055000e-02" in line_by_line_material
+        assert "      050122.30c  1.157500e-02" in line_by_line_material
+        assert "      050124.30c  1.447500e-02" in line_by_line_material
+        assert "      050114.30c  1.650000e-03" in line_by_line_material
+        assert "      050117.30c  1.920000e-02" in line_by_line_material
+        assert "      050116.30c  3.635000e-02" in line_by_line_material
 
     def test_mcnp_material_lines_contain_underscore(self):
         test_material = nmm.Material(
@@ -221,17 +221,17 @@ class test_object_properties(unittest.TestCase):
         assert line_by_line_material[0].split()[0] == "mat"
         assert line_by_line_material[0].split()[1] == "test"
         assert float(line_by_line_material[0].split()[2]) == pytest.approx(3)
-        assert "     041093.30c  0.75" in line_by_line_material
-        assert "     050112.30c  0.002425" in line_by_line_material
-        assert "     050114.30c  0.00165" in line_by_line_material
-        assert "     050115.30c  0.00085" in line_by_line_material
-        assert "     050116.30c  0.03635" in line_by_line_material
-        assert "     050117.30c  0.0192" in line_by_line_material
-        assert "     050118.30c  0.06055" in line_by_line_material
-        assert "     050119.30c  0.021475" in line_by_line_material
-        assert "     050120.30c  0.08145" in line_by_line_material
-        assert "     050122.30c  0.011575" in line_by_line_material
-        assert "     050124.30c  0.014475" in line_by_line_material
+        assert "      041093.30c  7.500000e-01" in line_by_line_material
+        assert "      050120.30c  8.145000e-02" in line_by_line_material
+        assert "      050119.30c  2.147500e-02" in line_by_line_material
+        assert "      050115.30c  8.500000e-04" in line_by_line_material
+        assert "      050112.30c  2.425000e-03" in line_by_line_material
+        assert "      050118.30c  6.055000e-02" in line_by_line_material
+        assert "      050122.30c  1.157500e-02" in line_by_line_material
+        assert "      050124.30c  1.447500e-02" in line_by_line_material
+        assert "      050114.30c  1.650000e-03" in line_by_line_material
+        assert "      050117.30c  1.920000e-02" in line_by_line_material
+        assert "      050116.30c  3.635000e-02" in line_by_line_material
 
     def test_material_creation_from_chemical_formula_with_enrichment(self):
 


### PR DESCRIPTION
Formatting changes to mcnp and serpent material output format for floats, to create a uniform scientific format.