### PR TITLE
added tests to check density it made on creation

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -239,7 +239,7 @@ class Material:
                     raise ValueError(
                         "pressure_in_Pa is needed for",
                         self.material_name)
-        
+
         self._make_openmc_material()
 
     @property

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -239,6 +239,8 @@ class Material:
                     raise ValueError(
                         "pressure_in_Pa is needed for",
                         self.material_name)
+        
+        self._make_openmc_material()
 
     @property
     def openmc_material(self):

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -14,6 +14,18 @@ import neutronics_material_maker as nmm
 
 class test_object_properties(unittest.TestCase):
 
+    def test_density_of_material_is_set_from_equation(self):
+        test_mat = nmm.Material('FLiBe', temperature_in_K=80, pressure_in_Pa=1)
+        assert test_mat.density is not None
+
+    def test_density_of_material_is_set_from_crystal(self):
+        test_mat = nmm.Material('Li4SiO4')
+        assert test_mat.density is not None
+
+    def test_density_of_material_is_set(self):
+        test_mat = nmm.Material('eurofer')
+        assert test_mat.density is not None
+
     def test_material_from_elements(self):
         test_mat = nmm.Material(material_name='test',
                                 elements={'Li': 0.4, 'Zr': 0.6},
@@ -21,6 +33,8 @@ class test_object_properties(unittest.TestCase):
                                 density=1,
                                 density_unit='g/cm3')
         test_mat.openmc_material
+        assert 'Li6' in test_mat.openmc_material.get_nuclides()
+        assert 'Li7' in test_mat.openmc_material.get_nuclides()
 
     def test_material_from_isotopes(self):
         test_mat = nmm.Material(material_name='test',
@@ -28,7 +42,8 @@ class test_object_properties(unittest.TestCase):
                                 percent_type='ao',
                                 density=1,
                                 density_unit='g/cm3')
-        test_mat.openmc_material
+        assert 'Li6' in test_mat.openmc_material.get_nuclides()
+        assert 'Li7' in test_mat.openmc_material.get_nuclides()
 
     def test_material_from_zaid_int_isotopes(self):
         test_mat = nmm.Material(material_name='test',
@@ -37,6 +52,8 @@ class test_object_properties(unittest.TestCase):
                                 density=1,
                                 density_unit='g/cm3')
         test_mat.openmc_material
+        assert 'Li6' in test_mat.openmc_material.get_nuclides()
+        assert 'Li7' in test_mat.openmc_material.get_nuclides()
 
     def test_material_from_zaid_str_isotopes(self):
         test_mat = nmm.Material(material_name='test',
@@ -45,6 +62,8 @@ class test_object_properties(unittest.TestCase):
                                 density=1,
                                 density_unit='g/cm3')
         test_mat.openmc_material
+        assert 'Li6' in test_mat.openmc_material.get_nuclides()
+        assert 'Li7' in test_mat.openmc_material.get_nuclides()
 
     def test_iron_density(self):
         a = nmm.Material("Iron")


### PR DESCRIPTION
This PR adds solves the issue of material density not being set after the material was constructed

This occurred when materials like He, FLiBe and others had their density made via a density_equation key

The error was also there for Li4SiO4 and other materials that had density calculated from a crystal lattice equation

This simply calls _make_openmc_material in the init which populates the density attribute when it is not already present

Tests have been added for the different types of materials 