### PR TITLE
Replace eval with asteval (#97)

### DIFF
--- a/requirments.txt
+++ b/requirments.txt
@@ -1,2 +1,3 @@
+asteval==0.9.19
 CoolProp
 openmc

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
     tests_require=["pytest-cov", "pytest-runner"],
     install_requires=[
         "coolprop",
+        "asteval",
         # 'openmc' when pip install is available
     ],
 )

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -722,6 +722,17 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["temperature_in_C"] == 100
         assert test_material_in_json_form["material_name"] == "H2O"
 
+    @staticmethod
+    def test_restricted_eval():
+        """Test that arbitrary commands cannot be injected."""
+        with pytest.raises(NameError):
+            nmm.Material(
+                "BadMaterial",
+                temperature_in_C=100,
+                pressure_in_Pa=1e6,
+                density_equation="os.system('ls')"
+            )
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
* Introduce asteval as a dependency

* Use an asteval interpreter

Make sure the temperature and pressure can be set in the symbol table.
Raise error if asteval detects invalid input.
Rework checks for OpenMC being available, allowing exceptions to be
raised if OpenMC materials aren't created successfully when OpenMC is
installed.
Implement a test to check that arbitrary code in the density_equation
results in an error.

Co-authored-by: Jonathan Shimwell <jonathan.shimwell@ukaea.uk>
Co-authored-by: autopep8 <autopep8@users.noreply.github.com>