### PR TITLE
Adds temperature to openmc materials and serpent materials

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -87,14 +87,16 @@ class Material:
             temperature have density equations that depend on temperature.
             These tend to be liquids and gases used for coolants and even
             liquids such as lithium-lead and FLiBe that are used as a breeder
-            materials.
+            materials. Convered to K and added to the openmc material object 
+            and the serpent material card.
         temperature_in_K (float): The temperature of the material in degrees
             Kelvin. Temperature impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
             temperature have density equations that depend on temperature.
             These tend to be liquids and gases used for coolants and even
             liquids such as lithium-lead and FLiBe that are used as breeder
-            materials.
+            materials. Added to the openmc material object and the serpent
+            material card.
         pressure_in_Pa (float): The pressure of the material in Pascals
             Pressure impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
@@ -235,7 +237,7 @@ class Material:
                     if temperature_in_K is None:
                         self.temperature_in_K = temperature_in_C + 273.15
                     if temperature_in_C is None:
-                        self.temperature_in_C = temperature_in_K + 273.15
+                        self.temperature_in_C = temperature_in_K - 273.15
 
             if "pressure_dependant" in material_dict[self.material_name].keys(
             ):

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -87,7 +87,7 @@ class Material:
             temperature have density equations that depend on temperature.
             These tend to be liquids and gases used for coolants and even
             liquids such as lithium-lead and FLiBe that are used as a breeder
-            materials. Convered to K and added to the openmc material object 
+            materials. Convered to K and added to the openmc material object
             and the serpent material card.
         temperature_in_K (float): The temperature of the material in degrees
             Kelvin. Temperature impacts the density of some materials in the

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -601,9 +601,13 @@ class Material:
             name = self.material_tag
         if self.material_id is not None:
             openmc_material = openmc.Material(
-                material_id=self.material_id, name=name)
+                material_id=self.material_id,
+                name=name,
+                temperature=self.temperature_in_K)
         else:
-            openmc_material = openmc.Material(name=name)
+            openmc_material = openmc.Material(
+                name=name,
+                temperature=self.temperature_in_K)
 
         if self.isotopes is not None:
 

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -66,7 +66,7 @@ class MultiMaterial:
         volume_in_cm3 (float): The volume of the material in cm3, used when
             creating fispact material cards
         temperature_in_C (float): The temperature of the material in degrees
-            Celsius. Convered to K and added to the openmc material object and 
+            Celsius. Convered to K and added to the openmc material object and
             the serpent material card
         temperature_in_K (float): The temperature of the material in degrees
             Kelvin. Added to the openmc material object and the serpent

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -58,6 +58,8 @@ def make_serpent_material(mat):
 
     mat_card = ["mat " + name + " " +
                 str(mat.openmc_material.get_mass_density())]
+    if mat.temperature_in_K is not None:
+        mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' ' 
     # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -59,7 +59,7 @@ def make_serpent_material(mat):
     mat_card = ["mat " + name + " " +
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_in_K is not None:
-        mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' ' 
+        mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' '
     # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.10",
+    version="0.1.11",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -369,7 +369,8 @@ class test_object_properties(unittest.TestCase):
             rel=0.01,
         )
         assert li7_atom_count == pytest.approx(
-            ((100.0 - enrichment) / 100) * (li_fraction / (pb_fraction + li_fraction)),
+            ((100.0 - enrichment) / 100) *
+             (li_fraction / (pb_fraction + li_fraction)),
             rel=0.01,
         )
 
@@ -982,11 +983,13 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.Material('WC')
         assert test_material.openmc_material.temperature is None
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> 437a424559206c118b095d7283d21d3307d75acb
+
+<< << << < HEAD
+
+== == == =
+
+>>>>>> > 437a424559206c118b095d7283d21d3307d75acb
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] != "300"

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -981,12 +981,12 @@ class test_object_properties(unittest.TestCase):
         attribute of the openmc materials"""
 
         test_material = nmm.Material('WC')
-        assert test_material.openmc_material.temperature == None
+        assert test_material.openmc_material.temperature is None
         
         line_by_line_material = test_material.serpent_material.split("\n")
 
-        assert line_by_line_material[0].split()[-1] is not "300"
-        assert line_by_line_material[0].split()[-2] is not "tmp"
+        assert line_by_line_material[0].split()[-1] != "300"
+        assert line_by_line_material[0].split()[-2] != "tmp"
 
     @staticmethod
     def test_restricted_eval():

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -938,6 +938,28 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["temperature_in_C"] == 100
         assert test_material_in_json_form["material_name"] == "H2O"
 
+    def test_temperature_from_C_in_openmc_material(self):
+        """checks that the temperature set in C ends up in the temperature
+        attribute of the openmc materials"""
+
+        test_material = nmm.Material(
+            'H2O',
+            temperature_in_C=10,
+            pressure_in_Pa=15.5e6
+        )
+        assert test_material.openmc_material.temperatue == 283.15
+
+    def test_temperature_from_K_in_openmc_material(self):
+        """checks that the temperature set in K ends up in the temperature
+        attribute of the openmc materials"""
+
+        test_material = nmm.Material(
+            'H2O',
+            temperature_in_K=300,
+            pressure_in_Pa=15.5e6
+        )
+        assert test_material.openmc_material.temperatue == 300
+
     @staticmethod
     def test_restricted_eval():
         """Test that arbitrary commands cannot be injected."""

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -574,7 +574,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_enrichment_target)
 
         def test_missing_temperature_He():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 material_name="He",
@@ -584,7 +584,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_missing_temperature_He)
 
         def test_missing_temperature_H2O():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 material_name="H2O",
@@ -594,7 +594,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_missing_temperature_H2O)
 
         def test_missing_temperature_CO2():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 material_name="CO2",
@@ -604,7 +604,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_missing_temperature_CO2)
 
         def test_incorrect_material_name_type():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             test_material = nmm.Material("H2O",
                                          temperature_in_C=10,
@@ -614,7 +614,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_material_name_type)
 
         def test_incorrect_density_unit_type():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -624,7 +624,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_density_unit_type)
 
         def test_incorrect_percent_type_type():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -634,7 +634,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_percent_type_type)
 
         def test_incorrect_enrichment_type_type():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -644,7 +644,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_enrichment_type_type)
 
         def test_incorrect_atoms_per_unit_cell():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -653,7 +653,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_atoms_per_unit_cell)
 
         def test_incorrect_volume_of_unit_cell_cm3():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -662,7 +662,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_volume_of_unit_cell_cm3)
 
         def test_incorrect_temperature_in_c():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -671,7 +671,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_temperature_in_c)
 
         def test_incorrect_temperature_in_k():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -680,7 +680,7 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, test_incorrect_temperature_in_k)
 
         def test_incorrect_zaid_suffix_type():
-            """checks a ValueError is raised when the temperatue is not set"""
+            """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
@@ -947,8 +947,11 @@ class test_object_properties(unittest.TestCase):
             temperature_in_C=10,
             pressure_in_Pa=15.5e6
         )
-        assert test_material.openmc_material.temperatue == 283.15
-        
+
+        assert test_material.temperature_in_K == 283.15
+        assert test_material.temperature_in_C == 10
+        assert test_material.openmc_material.temperature == 283.15
+    
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] == "283.15"
@@ -963,7 +966,10 @@ class test_object_properties(unittest.TestCase):
             temperature_in_K=300,
             pressure_in_Pa=15.5e6
         )
-        assert test_material.openmc_material.temperatue == 300
+
+        assert test_material.temperature_in_K == 300
+        assert test_material.temperature_in_C == pytest.approx(26.85)
+        assert test_material.openmc_material.temperature == 300
         
         line_by_line_material = test_material.serpent_material.split("\n")
 
@@ -974,12 +980,8 @@ class test_object_properties(unittest.TestCase):
         """checks that the temperature set in K ends up in the temperature
         attribute of the openmc materials"""
 
-        test_material = nmm.Material(
-            'H2O',
-            temperature_in_K=300,
-            pressure_in_Pa=15.5e6
-        )
-        assert test_material.openmc_material.temperatue == None
+        test_material = nmm.Material('WC')
+        assert test_material.openmc_material.temperature == None
         
         line_by_line_material = test_material.serpent_material.split("\n")
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -982,11 +982,7 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.Material('WC')
         assert test_material.openmc_material.temperature is None
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> 437a424559206c118b095d7283d21d3307d75acb
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] != "300"

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -938,7 +938,7 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["temperature_in_C"] == 100
         assert test_material_in_json_form["material_name"] == "H2O"
 
-    def test_temperature_from_C_in_openmc_material(self):
+    def test_temperature_from_C_in_materials(self):
         """checks that the temperature set in C ends up in the temperature
         attribute of the openmc materials"""
 
@@ -948,8 +948,13 @@ class test_object_properties(unittest.TestCase):
             pressure_in_Pa=15.5e6
         )
         assert test_material.openmc_material.temperatue == 283.15
+        
+        line_by_line_material = test_material.serpent_material.split("\n")
 
-    def test_temperature_from_K_in_openmc_material(self):
+        assert line_by_line_material[0].split()[-1] == "283.15"
+        assert line_by_line_material[0].split()[-2] == "tmp"
+
+    def test_temperature_from_K_in_materials(self):
         """checks that the temperature set in K ends up in the temperature
         attribute of the openmc materials"""
 
@@ -959,6 +964,27 @@ class test_object_properties(unittest.TestCase):
             pressure_in_Pa=15.5e6
         )
         assert test_material.openmc_material.temperatue == 300
+        
+        line_by_line_material = test_material.serpent_material.split("\n")
+
+        assert line_by_line_material[0].split()[-1] == "300"
+        assert line_by_line_material[0].split()[-2] == "tmp"
+
+    def test_temperature_not_in_materials(self):
+        """checks that the temperature set in K ends up in the temperature
+        attribute of the openmc materials"""
+
+        test_material = nmm.Material(
+            'H2O',
+            temperature_in_K=300,
+            pressure_in_Pa=15.5e6
+        )
+        assert test_material.openmc_material.temperatue == None
+        
+        line_by_line_material = test_material.serpent_material.split("\n")
+
+        assert line_by_line_material[0].split()[-1] is not "300"
+        assert line_by_line_material[0].split()[-2] is not "tmp"
 
     @staticmethod
     def test_restricted_eval():

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -370,7 +370,7 @@ class test_object_properties(unittest.TestCase):
         )
         assert li7_atom_count == pytest.approx(
             ((100.0 - enrichment) / 100) *
-             (li_fraction / (pb_fraction + li_fraction)),
+            (li_fraction / (pb_fraction + li_fraction)),
             rel=0.01,
         )
 

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -951,7 +951,7 @@ class test_object_properties(unittest.TestCase):
         assert test_material.temperature_in_K == 283.15
         assert test_material.temperature_in_C == 10
         assert test_material.openmc_material.temperature == 283.15
-    
+
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] == "283.15"
@@ -970,7 +970,7 @@ class test_object_properties(unittest.TestCase):
         assert test_material.temperature_in_K == 300
         assert test_material.temperature_in_C == pytest.approx(26.85)
         assert test_material.openmc_material.temperature == 300
-        
+
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] == "300"
@@ -981,8 +981,8 @@ class test_object_properties(unittest.TestCase):
         attribute of the openmc materials"""
 
         test_material = nmm.Material('WC')
-        assert test_material.openmc_material.temperature == None
-        
+        assert test_material.openmc_material.temperature is None
+
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] is not "300"

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -542,7 +542,7 @@ class test_object_properties(unittest.TestCase):
         assert test_material.temperature_in_K == 283.15
         assert test_material.temperature_in_C == 10
         assert test_material.openmc_material.temperature == 283.15
-    
+
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] == "283.15"
@@ -565,11 +565,12 @@ class test_object_properties(unittest.TestCase):
         assert test_material.temperature_in_K == 300
         assert test_material.temperature_in_C == pytest.approx(26.85)
         assert test_material.openmc_material.temperature == 300
-        
+
         line_by_line_material = test_material.serpent_material.split("\n")
 
         assert line_by_line_material[0].split()[-1] == "300"
         assert line_by_line_material[0].split()[-2] == "tmp"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -525,6 +525,51 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, test_too_small_packing_fraction)
 
+    def test_temperature_from_C_in_multimaterials(self):
+        """checks that the temperature set in C ends up in the temperature
+        attribute of the openmc multimaterials"""
+
+        test_material = nmm.MultiMaterial(
+            "test_material",
+            materials=[
+                nmm.Material("tungsten"),
+                nmm.Material("eurofer"),
+            ],
+            fracs=[0.3, 0.7],
+            temperature_in_C=10
+        )
+
+        assert test_material.temperature_in_K == 283.15
+        assert test_material.temperature_in_C == 10
+        assert test_material.openmc_material.temperature == 283.15
+    
+        line_by_line_material = test_material.serpent_material.split("\n")
+
+        assert line_by_line_material[0].split()[-1] == "283.15"
+        assert line_by_line_material[0].split()[-2] == "tmp"
+
+    def test_temperature_from_K_in_multimaterials(self):
+        """checks that the temperature set in K ends up in the temperature
+        attribute of the openmc multimaterials"""
+
+        test_material = nmm.MultiMaterial(
+            "test_material",
+            materials=[
+                nmm.Material("tungsten"),
+                nmm.Material("eurofer"),
+            ],
+            fracs=[0.3, 0.7],
+            temperature_in_K=300
+        )
+
+        assert test_material.temperature_in_K == 300
+        assert test_material.temperature_in_C == pytest.approx(26.85)
+        assert test_material.openmc_material.temperature == 300
+        
+        line_by_line_material = test_material.serpent_material.split("\n")
+
+        assert line_by_line_material[0].split()[-1] == "300"
+        assert line_by_line_material[0].split()[-2] == "tmp"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR address issue #69 and updates the PyPi and Conda distributions

Materials and MultiMaterials now add any temperature information they have to the serpent_material material card and the openmc_material

A few more tests were added and a temperature related bug was also fixed