### PR TITLE
Callable density property

### DIFF
--- a/neutronics_material_maker/__init__.py
+++ b/neutronics_material_maker/__init__.py
@@ -10,3 +10,4 @@ from .utils import zaid_to_isotope
 
 from .material import Material
 from .mutlimaterial import MultiMaterial
+from .properties import MaterialProperty, Density

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -212,7 +212,8 @@ class Material:
             if density is not None and density_equation is None:
                 self.density = Density(value=density, unit=density_unit)
             elif density is None and density_equation is not None:
-                self.density = Density(value=density_equation, unit=density_unit)
+                self.density = Density(
+                    value=density_equation, unit=density_unit)
 
         # derived values
         self.openmc_material = None

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -219,13 +219,6 @@ class Material:
                         needed to enrich a material"
                     )
 
-            if "pressure_dependant" in material_dict[self.material_name].keys(
-            ):
-                if pressure_in_Pa is None:
-                    raise ValueError(
-                        "pressure_in_Pa is needed for",
-                        self.material_name)
-
         # this populates the density of materials when density is provided by
         # equations and crystal latic information by making the openmc material
         # however it should also be possible to ininitialize nmm.Material
@@ -643,6 +636,18 @@ class Material:
                     self.material_name,
                 )
 
+    def _validate_pressure(self, is_pressure_dependent):
+        """
+        Check that pressure is provided, if needed.
+
+        Args:
+            is_pressure_dependent (bool): True if the material should be
+                treated as pressure dependent.
+        """
+        if is_pressure_dependent and self.pressure_in_Pa is None:
+            raise ValueError(
+                "pressure_in_Pa is needed for ", self.material_name)
+
     def _populate_from_inbuilt_dictionary(self):
         """This runs on initilisation and if attributes of the Material object
         are not specified (left as None) then the internal material dictionary
@@ -685,6 +690,10 @@ class Material:
             and "pressure_in_Pa" in material_dict[self.material_name].keys()
         ):
             self.pressure_in_Pa = material_dict[self.material_name]["pressure_in_Pa"]
+
+        self._validate_pressure(
+            "pressure_dependant" in material_dict[self.material_name]
+        )
 
         if (
             self.packing_fraction is None

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -268,6 +268,14 @@ class MultiMaterial:
 
         materials_list = []
         for material in self.materials:
+            density_val = None
+            density_equation = None
+            if material.density is not None:
+                if isinstance(material.density.value, (float, int)):
+                    density_val = material.density.value
+                elif isinstance(material.density.value, str):
+                    density_equation = material.density.value
+
             materials_list.append(
                 {
                     "material_name": material.material_name,
@@ -279,8 +287,8 @@ class MultiMaterial:
                     "elements": material.elements,
                     "chemical_equation": material.chemical_equation,
                     "isotopes": material.isotopes,
-                    "density": material.density,
-                    "density_equation": material.density_equation,
+                    "density": density_val,
+                    "density_equation": density_equation,
                     "atoms_per_unit_cell": material.atoms_per_unit_cell,
                     "volume_of_unit_cell_cm3": material.volume_of_unit_cell_cm3,
                     "density_unit": material.density_unit,

--- a/neutronics_material_maker/properties.py
+++ b/neutronics_material_maker/properties.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+"""Defines a callable property for a material."""
+
+__author__ = "neutronics material maker development team"
+
+import asteval
+from CoolProp.CoolProp import PropsSI
+
+
+class MaterialProperty:
+    """
+    Defines a property of a material that can be called with arguments.
+
+    Intrinsic properties of materials, such as the density, can vary according
+    to external factors, such as temperature and pressure. The MaterialProperty
+    class represents this behaviour by encapsulating the details of that
+    property in a way that can be called at specific values or temperature and
+    pressure.
+
+    Args:
+        value (float, int, or str): This is the value of the property. It can
+            be either a floating point number, in which case the property is
+            constant at any temperature or press, or can be a string defining
+            an equation to be evaluated at a given value of temperature_in_C,
+            temperature_in_K, and/or pressure_in_Pa.
+    """
+
+    # Set any custom symbols for use in asteval
+    _asteval_user_symbols = {"PropsSI": PropsSI}
+
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(
+        self,
+        temperature_in_C=None,
+        temperature_in_K=None,
+        pressure_in_Pa=None
+    ):
+        """
+        Evaluate the property at a given temperature and/or pressure.
+
+        Args:
+            temperature_in_C (float): The temperature [°C].
+            temperature_in_K (float): The temperature [K].
+            pressure_in_Pa (float): The pressure [Pa].
+
+        Returns:
+            prop_val (float): The property evaluated at the given temperature
+                and/or pressure.
+        """
+        if isinstance(self.value, str):
+            aeval = asteval.Interpreter(usersyms=self._asteval_user_symbols)
+
+            if temperature_in_C is None and temperature_in_K is not None:
+                temperature_in_C = temperature_in_K - 273.15
+
+            if temperature_in_K is None and temperature_in_C is not None:
+                temperature_in_K = temperature_in_C + 273.15
+
+            property_map = {
+                "temperature_in_K": temperature_in_K,
+                "temperature_in_C": temperature_in_C,
+                "pressure_in_Pa": pressure_in_Pa,
+            }
+
+            # Potentially used in the eval part
+            missing_values = []
+            for prop_name, prop_value in property_map.items():
+                aeval.symtable[prop_name] = prop_value
+                if prop_name in self.value and prop_value is None:
+                    missing_values.append(prop_name)
+
+            if missing_values:
+                raise ValueError("MaterialProperty requires "
+                                 f"{' and '.join(missing_values)}"
+                                 " to evaluate.")
+
+            prop_val = aeval.eval(self.value)
+
+            if len(aeval.error) > 0:
+                raise aeval.error[0].exc(aeval.error[0].msg)
+
+            return prop_val
+        else:
+            return self.value
+
+    @property
+    def value(self):
+        """
+        Get the value of the material property.
+
+        Returns:
+            value (str, float, or int): The value of the material property
+        """
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        """
+        Set the value of the material property.
+
+        Args:
+            value (str, float, or int): The value of the material property
+        """
+        if not isinstance(value, (str, float, int)):
+            raise ValueError(
+                "The value of a MaterialProperty must be a string defining a "
+                "temperature-/pressure-dependent function or a constant real "
+                "numeric value.")
+
+        self._value = value
+
+
+class Density(MaterialProperty):
+    """
+    Defines a MaterialProperty to be used for Density calculations.
+
+    Checks that the density unit is valid.
+
+    Args:
+        value (float or str): This is the value of the property. It can be
+            either a floating point number, in which case the property is
+            constant at any temperature or press, or can be a string defining
+            an equation to be evaluated at a given value of temperature_in_C,
+            temperature_in_K, and/or pressure_in_Pa.
+        unit (str): The unit of the property.
+    """
+
+    _valid_units = ["g/cm3", "g/cc", "kg/m3", "atom/b-cm", "atom/cm3"]
+
+    def __init__(self, value, unit="g/cm3"):
+        self.value = value
+        self.unit = unit
+
+    @property
+    def unit(self):
+        """
+        Get the density unit.
+
+        Returns:
+            unit (str): The density unit.
+        """
+        return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        """
+        Set the density unit.
+
+        Args:
+            unit (str): The density unit.
+        """
+        if value not in self._valid_units:
+            raise ValueError(
+                f"Density unit must be one of {', '.join(self._valid_units)}."
+            )
+
+        self._unit = value

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -935,8 +935,10 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(ValueError, incorrect_setting_for_volume_in_cm3_2)
 
         def density_not_provided():
-            nmm.Material(material_tag="TestMat", elements={"H": 1}, percent_type="ao")
-        
+            nmm.Material(
+                material_tag="TestMat", elements={
+                    "H": 1}, percent_type="ao")
+
         self.assertRaises(ValueError, density_not_provided)
 
         def default_density_returns_bad_value():
@@ -946,7 +948,7 @@ class test_object_properties(unittest.TestCase):
                 percent_type="ao",
                 density_equation="array([1])"
             )
-        
+
         self.assertRaises(ValueError, default_density_returns_bad_value)
 
         def density_uses_bad_property():
@@ -956,7 +958,7 @@ class test_object_properties(unittest.TestCase):
                 percent_type="ao",
                 density=nmm.MaterialProperty(value=None),
             )
-        
+
         self.assertRaises(ValueError, density_uses_bad_property)
 
         def density_is_negative():
@@ -967,7 +969,7 @@ class test_object_properties(unittest.TestCase):
                 density_equation="temperature_in_C - 100",
                 temperature_in_C=50,
             )
-        
+
         self.assertRaises(ValueError, density_is_negative)
 
     def test_setting_for_volume_int(self):

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -997,7 +997,8 @@ class test_object_properties(unittest.TestCase):
                 "BadMaterial",
                 temperature_in_C=100,
                 pressure_in_Pa=1e6,
-                density_equation="os.system('ls')"
+                density_equation="os.system('ls')",
+                density_unit="g/cm3",
             )
 
 

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -426,6 +426,26 @@ class test_object_properties(unittest.TestCase):
         assert test_material_in_json_form["percent_type"] == "vo"
         assert test_material_in_json_form["packing_fraction"] == 1.0
 
+    def test_json_dump_equation_density(self):
+        test_material = nmm.MultiMaterial(
+            "test_material",
+            materials=[
+                nmm.Material(
+                    "H2O",
+                    packing_fraction=0.6,
+                    temperature_in_C=305,
+                    pressure_in_Pa=15.5e6
+                ),
+                nmm.Material("eurofer", packing_fraction=0.8),
+            ],
+            fracs=[0.3, 0.7],
+        )
+        test_material_in_json_form = test_material.to_json()
+
+        water_json = test_material_in_json_form["materials"][0]
+        assert water_json["density"] is None
+        assert water_json["density_equation"] is not None
+
     def test_incorrect_settings(self):
         def too_large_fracs():
             """checks a ValueError is raised when the fracs are above 1"""

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+__author__ = "neutronics material maker development team"
+
+import pytest
+import unittest
+
+import neutronics_material_maker as nmm
+
+
+class TestMaterialProperty(unittest.TestCase):
+    """Defines tests for the MaterialProperty class."""
+
+    def test_define_constant_value(self):
+        """A MaterialProperty defined with a constant numeric value."""
+        test_value = 3
+        prop = nmm.MaterialProperty(value=test_value)
+        assert prop() == test_value
+        assert prop(temperature_in_C=100) == test_value
+        assert prop(temperature_in_K=100) == test_value
+        assert prop(pressure_in_Pa=100) == test_value
+
+    def test_define_equation_value(self):
+        """A MaterialProperty defined with a string equation value."""
+        test_value = "3.75 * temperature_in_K"
+        prop = nmm.MaterialProperty(value=test_value)
+        with pytest.raises(ValueError):
+            prop() == test_value
+
+        calculated_value = 3.75 * 100
+        assert prop(temperature_in_K=100) == pytest.approx(calculated_value)
+
+        calculated_value = 3.75 * (100 + 273.15)
+        assert prop(temperature_in_C=100) == pytest.approx(calculated_value)
+        with pytest.raises(ValueError):
+            prop(pressure_in_Pa=100)
+
+    def test_validate_value(self):
+        """A MaterialProperty value must be str, int, or float."""
+        test_value = [1, 2, 3]
+        with pytest.raises(ValueError):
+            nmm.MaterialProperty(value=test_value)
+
+
+class TestDensity(unittest.TestCase):
+    """Defines tests for the Density class."""
+
+    def test_validate_units(self):
+        """Density units must be in the valid list."""
+        for unit in nmm.Density._valid_units:
+            prop = nmm.Density(value=3, unit=unit)
+            assert prop is not None
+
+        with pytest.raises(ValueError):
+            nmm.Density(value=3, unit="NotAUnit")
+
+
+if __name__ == "__main__":
+
+    unittest.main()


### PR DESCRIPTION
This PR looks to make it easier to evaluate material densities at different temperatures and pressures, while maintaining functionality. It also ensures that temperatures in C or K are kept in line if either are varied.

The main functional difference will be how density information is accessed. There are now a few options:

```python
density = material.default_density
```

This will evaluate the density `MaterialProperty` at the temperature and pressure of the material.

```python
density = material.density(temperature_in_C=100)
```

This will evaluate the material's density at the provided temperature (in C or K) or pressure.

The density_equation is no longer exposed after it has been set as it is wrapped into the density `MaterialProperty` e.g. it becomes `density.value`, as is the case for the provided density if it is a float of int value.

The density_unit is also not directly exposed but it can be retrieved via `material.density_unit` (which accesses `density.unit`).

This approach should also make it easier to expand the set of `MaterialProperty` attributes that are available to a material class, for example in other codebases.

Closes #103