### PR TITLE
adding shift material header and fixing docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - python=3.8
   - openmc
   - pip:
-    - coolprop
-    - asteval
+      - coolprop
+      - asteval

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,4 +4,8 @@ channels:
   - conda-forge
 
 dependencies:
+  - python=3.8
   - openmc
+  - pip:
+    - coolprop
+    - asteval

--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
   - openmc
   - pip:
-    - coolprop
-    - asteval
+      - coolprop
+      - asteval

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.8
   - openmc
   - pip:
     - coolprop

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - openmc
   - pip:
     - coolprop
+    - asteval

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -145,7 +145,8 @@ def make_shift_material(mat) -> str:
         name = mat.material_tag
 
     mat_card = [
-        "name %s\n" %name
+        "[COMP][MATERIAL]\n"
+        + "name %s\n" %name
         + "matid %s\n" %mat.material_id
         + "tmp %s" %mat.temperature_in_K
     ]

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -146,9 +146,9 @@ def make_shift_material(mat) -> str:
 
     mat_card = [
         "[COMP][MATERIAL]\n"
-        + "name %s\n" %name
-        + "matid %s\n" %mat.material_id
-        + "tmp %s" %mat.temperature_in_K
+        + "name %s\n" % name
+        + "matid %s\n" % mat.material_id
+        + "tmp %s" % mat.temperature_in_K
     ]
     zaid = 'zaid'
     nd_ = 'nd'

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -19,10 +19,10 @@ sphinx:
 #   - pdf
 
 # this is not needed if using conda environment
-python:
-  version: 3.8
-  install:
-    - requirements: requirements.txt
+# python:
+#   version: 3.8
+#   install:
+#     - requirements: requirements.txt
 
 # specify conda environment needed for build
 conda:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.14",
+    version="0.1.15",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.15",
+    version="0.1.16",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="jonathan.shimwell@ukaea.uk",


### PR DESCRIPTION
This PR brings the latest additions to the main branch

- Shift materials have had an additional line added
- The docs were not working for the materials and multimaterials classes as a package was missing from the enviroment.yml