### PR TITLE
Adding additional lines

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 UKAEA
+Copyright (c) 2020 UKAEA and neutronics-material-maker contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = "NeutronicsMaterialMaker"
-copyright = "2020, UKAEA"
+copyright = "2020, UKAEA and neutronics-material-maker contributors"
 author = "neutronics-material-maker development team"
 
 # The short X.Y version

--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -6,7 +6,7 @@ Usage - basic Material()
 
 Here is an example that accesses a material from the internal collection called eurofer which has about 60 isotopes and a density of 7.78g/cm3.
 
-::
+.. code-block:: python
 
    import neutronics_material_maker as nmm
 
@@ -14,21 +14,21 @@ Here is an example that accesses a material from the internal collection called 
 
 Once the object has been initiated the OpenMC or Serpent material card can be accessed.
 
-::
+.. code-block:: python
 
    my_mat.openmc_material
    my_mat.serpent_material
 
 To access MCNP material it is necessary to also provide an id.
 
-::
+.. code-block:: python
 
    my_mat = nmm.Material('eurofer', material_id=1)
    my_mat.mcnp_material
 
 To access the Fispact material it is necessary to also provide a volume.
 
-::
+.. code-block:: python
 
    my_mat = nmm.Material('eurofer', volume_in_cm3=10)
    my_mat.fispact_material
@@ -36,12 +36,10 @@ To access the Fispact material it is necessary to also provide a volume.
 To access the Shift material it is necessary to also provide a temperature and
 a material id
 
-::
+.. code-block:: python
 
    my_mat = nmm.Material('eurofer', temperature_in_K=293, material_id=1)
    my_mat.shift_material
-
-
 
 
 Usage - hot pressurised  Material()
@@ -49,7 +47,7 @@ Usage - hot pressurised  Material()
 
 For several materials within the collection the temperature and the pressure impacts the density of the material. The neutronics_material_maker adjusts the density to take temperature (in C or K) and the pressure into account when appropriate. Densities are calculated either by a material specific formula (for example `FLiBe <https://github.com/ukaea/neutronics_material_maker/blob/openmc_version/neutronics_material_maker/data/multiplier_and_breeder_materials.json>`_) or using `CoolProps <https://pypi.org/project/CoolProp/>`_ (for example coolants such as H2O).
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -59,14 +57,13 @@ For several materials within the collection the temperature and the pressure imp
 
 Temperature can be provided in degrees C or Kelvin.
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
     my_mat1 = nmm.Material('H2O', temperature_in_K=573.15, pressure_in_Pa=15e6)
 
     my_mat1.openmc_material
-
 
 
 Usage - enriched Material()
@@ -76,7 +73,7 @@ For several materials within the collection the density is adjusted when the mat
 
 Lithium ceramics used in fusion breeder blankets often contain enriched lithium-6 content. This slight change in density is accounted for by the neutronics_material_maker.
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -87,7 +84,7 @@ Lithium ceramics used in fusion breeder blankets often contain enriched lithium-
 
 The default enrichment target for 'Li4SiO4' is Li6 but this can be changed if required.
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -96,13 +93,12 @@ The default enrichment target for 'Li4SiO4' is Li6 but this can be changed if re
     my_mat2.openmc_material
 
 
-
 Usage - make a your own materials
 ---------------------------------
 
 Example making materials from elements
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -120,7 +116,7 @@ Example making materials from elements
 
 Example making materials from isotopes
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -137,7 +133,7 @@ Example making materials from isotopes
 
 Example making materials from isotopes defined by zaid
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
 
@@ -154,7 +150,7 @@ Example making materials from isotopes defined by zaid
 
 It is also possible to make your own materials directly from a dictionary by making use of the python syntax **
 
-::
+.. code-block:: python
 
     import neutronics_material_maker as nmm
     
@@ -170,3 +166,40 @@ It is also possible to make your own materials directly from a dictionary by mak
     }
 
     my_mat = nmm.Material(**my_dict)
+
+If you require additional lines at the end of the MCNP, Serpent, Fispact or
+Shift materia card then the additional_end_lines argument can be used. This
+will add specific line(s) to the end of a material card. Multiple lines can be
+added by creating a list wilth multiple entries.
+
+In this example the S(α,β) treatment of water to be correctly modeled in
+MCNP. But this could also be used to add comments to the material card or other
+text at the end of the material card string.
+
+.. code-block:: python
+
+    import neutronics_material_maker as nmm
+
+    my_mat2 = nmm.Material(
+    'H2O',
+    material_id=10,
+    temperature_in_K=573.15,
+    pressure_in_Pa=15e6,
+    additional_end_lines={'mcnp': ['      mt24 lwtr.01']}
+    )
+
+    my_mat2.mcnp_material
+
+The above code will return a MCNP material card string with the additional line
+'      mt24 lwtr.01' at the end. Notice that spaces should also be set by the
+user.
+
+.. code-block:: bash
+
+c     H2O density 7.25553605e-01 g/cm3
+M10   001001  6.66562840e-01
+      001002  1.03826667e-04
+      008016  3.32540200e-01
+      008017  1.26333333e-04
+      008018  6.66800000e-04
+      mt24 lwtr.01

--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -184,11 +184,11 @@ text at the end of the material card string.
     import neutronics_material_maker as nmm
 
     my_mat2 = nmm.Material(
-    'H2O',
-    material_id=10,
-    temperature_in_K=573.15,
-    pressure_in_Pa=15e6,
-    additional_end_lines={'mcnp': ['      mt24 lwtr.01']}
+        'H2O',
+        material_id=1,
+        temperature_in_K=573.15,
+        pressure_in_Pa=15e6,
+        additional_end_lines={'mcnp': ['      mt24 lwtr.01']}
     )
 
     my_mat2.mcnp_material
@@ -199,10 +199,10 @@ user.
 
 .. code-block:: bash
 
-c     H2O density 7.25553605e-01 g/cm3
-M10   001001  6.66562840e-01
-      001002  1.03826667e-04
-      008016  3.32540200e-01
-      008017  1.26333333e-04
-      008018  6.66800000e-04
-      mt24 lwtr.01
+    c     H2O density 7.25553605e-01 g/cm3
+    M10   001001  6.66562840e-01
+        001002  1.03826667e-04
+        008016  3.32540200e-01
+        008017  1.26333333e-04
+        008018  6.66800000e-04
+        mt24 lwtr.01

--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -173,11 +173,12 @@ Usage - adding extra lines to a material card
 If you require additional lines at the end of the MCNP, Serpent, Fispact or
 Shift materia card then the additional_end_lines argument can be used. This
 will add specific line(s) to the end of a material card. Multiple lines can be
-added by creating a list wilth multiple entries.
+added by creating a list with multiple entries.
 
-In this example the S(α,β) treatment of water to be correctly modeled in
-MCNP. But this could also be used to add comments to the material card or other
-text at the end of the material card string.
+In this example and additional line can be added to allow the S(α,β) treatment
+of water to be correctly modeled in MCNP. But this could also be used to add
+comments to the material card or other text at the end of the material card
+string.
 
 .. code-block:: python
 

--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -167,6 +167,9 @@ It is also possible to make your own materials directly from a dictionary by mak
 
     my_mat = nmm.Material(**my_dict)
 
+Usage - adding extra lines to a material card
+---------------------------------------------
+
 If you require additional lines at the end of the MCNP, Serpent, Fispact or
 Shift materia card then the additional_end_lines argument can be used. This
 will add specific line(s) to the end of a material card. Multiple lines can be

--- a/neutronics_material_maker/__init__.py
+++ b/neutronics_material_maker/__init__.py
@@ -8,6 +8,7 @@ from .utils import AvailableMaterials
 from .utils import material_dict
 from .utils import isotope_to_zaid
 from .utils import zaid_to_isotope
+from .utils import check_add_additional_end_lines
 
 from .material import Material
 from .mutlimaterial import MultiMaterial

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -18,6 +18,7 @@ from neutronics_material_maker import (
     make_shift_material,
     material_dict,
     zaid_to_isotope,
+    check_add_additional_end_lines
 )
 
 OPENMC_AVAILABLE = True
@@ -276,28 +277,7 @@ class Material:
 
     @additional_end_lines.setter
     def additional_end_lines(self, value):
-        if value is not None:
-            string_codes = ['mcnp', 'serpent', 'shift', 'fispact']
-            if not isinstance(value, dict):
-                raise ValueError(
-                    'Material.additional_end_lines should be a dictionary')
-            for key, entries in value.items():
-                if key not in string_codes:
-                    raise ValueError(
-                        'Material.additional_end_lines should be a '
-                        'dictionary where the keys are the name of the neutronics'
-                        'code. Acceptable values are {}'.format(string_codes))
-                if not isinstance(entries, list):
-                    raise ValueError(
-                        'Material.additional_end_lines should be a'
-                        ' dictionary where the value of each dictionary entry is a'
-                        ' list')
-                for entry in entries:
-                    if not isinstance(entry, str):
-                        raise ValueError(
-                            'Material.additional_end_lines should be'
-                            'a dictionary where the value of each dictionary entry'
-                            ' is a list of strings')
+        check_add_additional_end_lines(value)
 
         self._additional_end_lines = value
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -64,7 +64,7 @@ class Material:
 
     Args:
         material_name: This is the reference name used to look up the material
-            from the internal collection. Look up the available materials 
+            from the internal collection. Look up the available materials
             AvailableMaterials()
         material_tag (str): This is a string that is assigned to the
             material as an identifier. This is used by neutronics
@@ -136,7 +136,7 @@ class Material:
         additional_end_lines: Additional lines of test that are added to the end of
             the material card. Compatable with MCNP, Serpent, Fispact outputs
             which are string based. Agument should be a dictionary specifying
-            the code and a list of lines to be added, besure to include any 
+            the code and a list of lines to be added, besure to include any
             white required spaces in the string. This example will add a single
             S(a,b) card to an MCNP card {'mnnp': ['        mt24 lwtr.01']}.
 
@@ -279,19 +279,23 @@ class Material:
         if value is not None:
             string_codes = ['mcnp', 'serpent', 'shift', 'fispact']
             if not isinstance(value, dict):
-                raise ValueError('Material.additional_end_lines should be a dictionary')
+                raise ValueError(
+                    'Material.additional_end_lines should be a dictionary')
             for key, entries in value.items():
                 if key not in string_codes:
-                    raise ValueError('Material.additional_end_lines should be a '
+                    raise ValueError(
+                        'Material.additional_end_lines should be a '
                         'dictionary where the keys are the name of the neutronics'
                         'code. Acceptable values are {}'.format(string_codes))
                 if not isinstance(entries, list):
-                    raise ValueError('Material.additional_end_lines should be a'
+                    raise ValueError(
+                        'Material.additional_end_lines should be a'
                         ' dictionary where the value of each dictionary entry is a'
                         ' list')
                 for entry in entries:
                     if not isinstance(entry, str):
-                        raise ValueError('Material.additional_end_lines should be'
+                        raise ValueError(
+                            'Material.additional_end_lines should be'
                             'a dictionary where the value of each dictionary entry'
                             ' is a list of strings')
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -703,6 +703,7 @@ class Material:
         dictionary then these are used to populated the attributes of the
         Material object when present.
         """
+
         if (
             self.material_id is None
             and "material_id" in material_dict[self.material_name].keys()

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -67,14 +67,14 @@ class Material:
         material_name: This is the reference name used to look up the material
             from the internal collection. Look up the available materials
             AvailableMaterials()
-        material_tag (str): This is a string that is assigned to the
+        material_tag: This is a string that is assigned to the
             material as an identifier. This is used by neutronics
             codes to label the material with a unique identifier
-        packing_fraction (float): This value is mutliplied by the density
+        packing_fraction: This value is mutliplied by the density
             which allows packing_fraction to be taken into account for materials
             involving an amount of void. Recall that packing_fraction is equal
             to 1/void fraction
-        enrichment (float): This is the percentage of isotope enrichment
+        enrichment: This is the percentage of isotope enrichment
             required for the material. This works for materials that have
             an enrichment_target specified. The internal material collection
             have Li6 specified as an enrichment_target for Lithium containing
@@ -82,8 +82,8 @@ class Material:
             the internal package materials take this into account. It is also
             possible to use this when making materials not included in the
             reference collection but an enrichment_target must also be provided.
-        enrichment_target (str): The isotope to enrich e.g. Li6
-        temperature_in_C (float): The temperature of the material in degrees
+        enrichment_target: The isotope to enrich e.g. Li6
+        temperature_in_C: The temperature of the material in degrees
             Celsius. Temperature impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
             temperature have density equations that depend on temperature.
@@ -91,7 +91,7 @@ class Material:
             liquids such as lithium-lead and FLiBe that are used as a breeder
             materials. Convered to K and added to the openmc material object
             and the serpent material card.
-        temperature_in_K (float): The temperature of the material in degrees
+        temperature_in_K: The temperature of the material in degrees
             Kelvin. Temperature impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
             temperature have density equations that depend on temperature.
@@ -99,40 +99,39 @@ class Material:
             liquids such as lithium-lead and FLiBe that are used as breeder
             materials. Added to the openmc material object and the serpent
             material card.
-        pressure_in_Pa (float): The pressure of the material in Pascals
+        pressure_in_Pa: The pressure of the material in Pascals
             Pressure impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
             pressure have density equations that depend on pressure.
             These tend to be liquids and gases used for coolants such as
             H2O and CO2.
-        zaid_suffix (str): The nuclear library to apply to the zaid, for
+        zaid_suffix: The nuclear library to apply to the zaid, for
             example ".31c", this is used in MCNP and Serpent material cards.
-        material_id (int): the id number or mat number used in the MCNP material
-            card
-        decimal_places (int): The number of decimal places to use in MCNP and
+        material_id: the id number or mat number used in the MCNP material card
+        decimal_places: The number of decimal places to use in MCNP and
             Seprent material cards when they are printed out (default of 8).
-        volume_in_cm3 (float): The volume of the material in cm3, used when
+        volume_in_cm3: The volume of the material in cm3, used when
             creating fispact material cards
-        elements (dict): A dictionary of keys and values with the element symbol
+        elements: A dictionary of keys and values with the element symbol
             (str) as the key and the amount of that element as the value (float)
             e.g. {'C': 0.3333, 'O': 0.666}
-        chemical_equation (str): A chemical equation that identifies elements
+        chemical_equation: A chemical equation that identifies elements
             and numbers of elements to add to the material e.g. 'CO2' or 'H2O'
-        isotopes (dict): A dictionary of keys and values with the isotope symbol
+        isotopes: A dictionary of keys and values with the isotope symbol
             (str) as the key and the amount of that isotope (float) as the value
             e.g. {'Li6': 0.9, 'Li7': 0.1} alternatively zaid representation
             can also be used instead of the symbol e.g. {'3006': 0.9, '4007': 0.1}
-        percent_type (str): Atom "ao" or or weight fraction "wo"
-        density (float): value to be used as the density
-        density_unit (str): the units of density "g/cm3", "g/cc", "kg/m3",
+        percent_type: Atom "ao" or or weight fraction "wo"
+        density): value to be used as the density
+        density_unit: the units of density "g/cm3", "g/cc", "kg/m3",
             "atom/b-cm", "atom/cm3"
-        density_equation (str): An equation to be evaluated to find the density,
+        density_equation: An equation to be evaluated to find the density,
             can contain temperature_in_C, temperature_in_K and pressure_in_Pa
             variables as part of the equation.
-        atoms_per_unit_cell (int): The number of atoms in a unit cell of the
+        atoms_per_unit_cell: The number of atoms in a unit cell of the
             crystal structure
-        volume_of_unit_cell_cm3 (float): The volume of the unit cell in cm3
-        reference (str): An entry used to store information on the source of the
+        volume_of_unit_cell_cm3: The volume of the unit cell in cm3
+        reference: An entry used to store information on the source of the
             material data
         additional_end_lines: Additional lines of test that are added to the end of
             the material card. Compatable with MCNP, Serpent, Fispact outputs
@@ -266,12 +265,12 @@ class Material:
 
     @property
     def additional_end_lines(self):
-        """
-        Returns a dictionary of lists where each entry in the list is a to be
-        added to the end of the material card and each key is the name of the
-        neutronics code to add the line to.
+        """Returns a dictionary of lists where each entry in the list is a to
+        be added to the end of the material card and each key is the name of
+        the neutronics code to add the line to.
 
-        :type: openmc.Material() object
+        Returns:
+            dictionary of neutronics codes each with a list of lines to add
         """
         return self._additional_end_lines
 
@@ -283,10 +282,10 @@ class Material:
 
     @property
     def openmc_material(self):
-        """
-        Returns an OpenMC version of the Material.
+        """Creates an OpenMC version of the Material.
 
-        :type: openmc.Material() object
+        Returns:
+            openmc.Material() object
         """
         self._openmc_material = self._make_openmc_material()
         return self._openmc_material
@@ -297,10 +296,12 @@ class Material:
 
     @property
     def serpent_material(self):
-        """
-        Returns a Serpent version of the Material.
+        """Creates a a Serpent version of the Material with '\n' as line
+        endings. Decimal places can be controlled with the
+        Material.decimal_places attribute.
 
-        :type: str
+        Returns:
+            A Serpent material card
         """
 
         self._serpent_material = make_serpent_material(self)
@@ -312,13 +313,12 @@ class Material:
 
     @property
     def mcnp_material(self):
-        """
-        Returns a MCNP version of the Material. Requires the
-        Material.material_id to be set. Decimal places can be controlled with
-        the Material.decimal_places attribute.
-        Temperature of the material is set as 273K.
+        """Creates a a MCNP version of the Material with '\n' as line endings.
+        Requires the Material.material_id to be set. Decimal places can be
+        controlled with the Material.decimal_places attribute.
 
-        :type: str
+        Returns:
+            A MCNP material card
         """
         self._mcnp_material = make_mcnp_material(self)
         return self._mcnp_material
@@ -329,12 +329,13 @@ class Material:
 
     @property
     def shift_material(self):
-        """
-        Returns a Shift version of the Material. Requires the
-        Material.material_id to be set. Decimal places can be controlled with
-        the Material.deicmal_places attribute.
+        """Creates a a Shift version of the Material with '\n' as line endings.
+        Requires the Material.material_id and Material.temperature_in_K to be
+        set. Decimal places can be controlled with the Material.deicmal_places
+        attribute.
 
-        :type: str
+        Returns:
+            A Shift material card
         """
         self._shift_material = make_shift_material(self)
         return self._shift_material
@@ -345,11 +346,11 @@ class Material:
 
     @property
     def fispact_material(self):
-        """
-        Returns a fispact version of the Material. Requires the
-        Material.volume_in_cm3 to be set.
+        """Creates a a FISPACT version of the Material with '\n' as line
+        endings. Requires the Material.volume_in_cm3 to be set.
 
-        :type: str
+        Returns:
+            A FISPACT material card
         """
         self._fispact_material = make_fispact_material(self)
         return self._fispact_material

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -10,7 +10,8 @@ import neutronics_material_maker as nmm
 from neutronics_material_maker import (make_fispact_material,
                                        make_mcnp_material,
                                        make_shift_material,
-                                       make_serpent_material)
+                                       make_serpent_material,
+                                       check_add_additional_end_lines)
 
 OPENMC_AVAILABLE = True
 try:
@@ -155,28 +156,7 @@ class MultiMaterial:
 
     @additional_end_lines.setter
     def additional_end_lines(self, value):
-        if value is not None:
-            string_codes = ['mcnp', 'serpent', 'shift', 'fispact']
-            if not isinstance(value, dict):
-                raise ValueError(
-                    'Material.additional_end_lines should be a dictionary')
-            for key, entries in value.items():
-                if key not in string_codes:
-                    raise ValueError(
-                        'Material.additional_end_lines should be a '
-                        'dictionary where the keys are the name of the neutronics'
-                        'code. Acceptable values are {}'.format(string_codes))
-                if not isinstance(entries, list):
-                    raise ValueError(
-                        'Material.additional_end_lines should be a'
-                        ' dictionary where the value of each dictionary entry is a'
-                        ' list')
-                for entry in entries:
-                    if not isinstance(entry, str):
-                        raise ValueError(
-                            'Material.additional_end_lines should be'
-                            'a dictionary where the value of each dictionary entry'
-                            ' is a list of strings')
+        check_add_additional_end_lines(value)
 
         self._additional_end_lines = value
 

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -45,41 +45,42 @@ class MultiMaterial:
     and openmc.Materials. The MultiMaterial object is json serializable.
 
     Args:
-        material_tag (str): This is a string that is assigned to the
-            material as an identifier. This is used by neutronics
-            codes to label the material with a unique identifier
-        materials (list): a list of neutronics_material_maker.Materials
+        material_tag: This is a string that is assigned to the material as an
+            identifier. This is used by neutronics codes to label the material
+            with a unique identifier
+        materials: a list of neutronics_material_maker.Materials
             or openmc.Materials that are to be mixed
-        fracs (list of floats): A list of fractions that represent the amount of
-            each material to mix
-        percent_type (str): Type of frac percentage, must be one of
+        fracs: A list of fractions that represent the amount of each material
+            to mix, should sum to 1.
+        percent_type: Type of frac percentage, must be one of
             atom percent 'ao', weight percent 'wo', or volume percent 'vo'.
             Defaults to 'vo'
-        packing_fraction (float): This value is multiplied by the density
-            which allows packing_fraction to be taken into account for materials
-            involving an amount of void. Recall that packing_fraction is equal
-            to 1/void fraction
-        zaid_suffix (str): The nuclear library to apply to the zaid, for example
+        packing_fraction: This value is multiplied by the density which allows
+            packing_fraction to be taken into account for materials involving
+            an amount of void. Recall that packing_fraction is equal to 1/void
+            fraction
+        zaid_suffix: The nuclear library to apply to the zaid, for example
             ".31c", this is used in MCNP and Serpent material cards.
-        material_id (int): The id number or mat number used in the MCNP material
+        material_id: The id number or mat number used in the MCNP material
             card
-        decimal_places (int): The number of decimal places to use in MCNP and
+        decimal_places: The number of decimal places to use in MCNP and
             Seprent material cards when they are printed out (default of 8).
-        volume_in_cm3 (float): The volume of the material in cm3, used when
+        volume_in_cm3: The volume of the material in cm3, used when
             creating fispact material cards
-        temperature_in_C (float): The temperature of the material in degrees
+        temperature_in_C: The temperature of the material in degrees
             Celsius. Convered to K and added to the openmc material object and
             the serpent material card
-        temperature_in_K (float): The temperature of the material in degrees
+        temperature_in_K: The temperature of the material in degrees
             Kelvin. Added to the openmc material object and the serpent
             material card
-        additional_end_lines: Additional lines of test that are added to the end of
-            the material card. Compatable with MCNP, Serpent, Fispact outputs
-            which are string based. Agument should be a dictionary specifying
-            the code and a list of lines to be added, besure to include any
-            white required spaces in the string. This example will add a single
-            S(a,b) card to an MCNP card {'mnnp': ['        mt24 lwtr.01']}.
-            Additional lines are not carried over from materials.
+        additional_end_lines: Additional lines of test that are added to the
+            end of the material card. Compatable with MCNP, Serpent, Fispact
+            outputs which are string based. Agument should be a dictionary
+            specifying the code and a list of lines to be added, besure to
+            include any white required spaces in the string. This example will
+            add a single S(a,b) card to an MCNP card
+            {'mnnp': ['        mt24 lwtr.01']}. Additional lines are not
+            carried over from materials.
 
     Returns:
         Material: a neutronics_material_maker.Material instance
@@ -145,12 +146,12 @@ class MultiMaterial:
 
     @property
     def additional_end_lines(self):
-        """
-        Returns a dictionary of lists where each entry in the list is a to be
-        added to the end of the material card and each key is the name of the
-        neutronics code to add the line to.
+        """Returns a dictionary of lists where each entry in the list is a to
+        be added to the end of the material card and each key is the name of
+        the neutronics code to add the line to.
 
-        :type: openmc.Material() object
+        Returns:
+            dictionary of neutronics codes each with a list of lines to add
         """
         return self._additional_end_lines
 
@@ -204,10 +205,10 @@ class MultiMaterial:
 
     @property
     def openmc_material(self):
-        """
-        Returns an OpenMC version of the Material.
+        """Creates an OpenMC version of the Material.
 
-        :type: openmc.Material() object
+        Returns:
+            openmc.Material() object
         """
         self._openmc_material = self._make_openmc_material()
         return self._openmc_material
@@ -217,11 +218,13 @@ class MultiMaterial:
         self._openmc_material = value
 
     @property
-    def serpent_material(self):
-        """
-        Returns a Serpent version of the Material.
+    def serpent_material(self) -> str:
+        """Creates a a Serpent version of the Material with '\n' as line
+        endings. Decimal places can be controlled with the
+        Material.decimal_places attribute.
 
-        :type: str
+        Returns:
+            A Serpent material card
         """
 
         self._serpent_material = make_serpent_material(self)
@@ -233,10 +236,12 @@ class MultiMaterial:
 
     @property
     def mcnp_material(self):
-        """
-        Returns a MCNP version of the Material.
+        """Creates a a MCNP version of the Material with '\n' as line endings.
+        Requires the Material.material_id to be set. Decimal places can be
+        controlled with the Material.decimal_places attribute.
 
-        :type: str
+        Returns:
+            A MCNP material card
         """
         self._mcnp_material = make_mcnp_material(self)
         return self._mcnp_material
@@ -247,10 +252,13 @@ class MultiMaterial:
 
     @property
     def shift_material(self):
-        """
-        Returns a Shift version of hte Material.
+        """Creates a a Shift version of the Material with '\n' as line endings.
+        Requires the Material.material_id and Material.temperature_in_K to be
+        set. Decimal places can be controlled with the Material.deicmal_places
+        attribute.
 
-        :type: str
+        Returns:
+            A Shift material card
         """
         self._shift_material = make_shift_material(self)
         return self._shift_material
@@ -261,10 +269,11 @@ class MultiMaterial:
 
     @property
     def fispact_material(self):
-        """
-        Returns a fispact version of the Material.
+        """Creates a a FISPACT version of the Material with '\n' as line
+        endings. Requires the Material.volume_in_cm3 to be set.
 
-        :type: str
+        Returns:
+            A FISPACT material card
         """
         self._fispact_material = make_fispact_material(self)
         return self._fispact_material

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -75,7 +75,7 @@ class MultiMaterial:
         additional_end_lines: Additional lines of test that are added to the end of
             the material card. Compatable with MCNP, Serpent, Fispact outputs
             which are string based. Agument should be a dictionary specifying
-            the code and a list of lines to be added, besure to include any 
+            the code and a list of lines to be added, besure to include any
             white required spaces in the string. This example will add a single
             S(a,b) card to an MCNP card {'mnnp': ['        mt24 lwtr.01']}.
             Additional lines are not carried over from materials.
@@ -158,19 +158,23 @@ class MultiMaterial:
         if value is not None:
             string_codes = ['mcnp', 'serpent', 'shift', 'fispact']
             if not isinstance(value, dict):
-                raise ValueError('Material.additional_end_lines should be a dictionary')
+                raise ValueError(
+                    'Material.additional_end_lines should be a dictionary')
             for key, entries in value.items():
                 if key not in string_codes:
-                    raise ValueError('Material.additional_end_lines should be a '
+                    raise ValueError(
+                        'Material.additional_end_lines should be a '
                         'dictionary where the keys are the name of the neutronics'
                         'code. Acceptable values are {}'.format(string_codes))
                 if not isinstance(entries, list):
-                    raise ValueError('Material.additional_end_lines should be a'
+                    raise ValueError(
+                        'Material.additional_end_lines should be a'
                         ' dictionary where the value of each dictionary entry is a'
                         ' list')
                 for entry in entries:
                     if not isinstance(entry, str):
-                        raise ValueError('Material.additional_end_lines should be'
+                        raise ValueError(
+                            'Material.additional_end_lines should be'
                             'a dictionary where the value of each dictionary entry'
                             ' is a list of strings')
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -14,6 +14,35 @@ except BaseException:
             .fispact_material not avaiable")
 
 
+def check_add_additional_end_lines(value):
+    """Uses to check the additional lines passed to Material and Multimaterial
+    classes are correctly formatted"""
+
+    if value is not None:
+        string_codes = ['mcnp', 'serpent', 'shift', 'fispact']
+        if not isinstance(value, dict):
+            raise ValueError(
+                'Material.additional_end_lines should be a dictionary')
+        for key, entries in value.items():
+            if key not in string_codes:
+                raise ValueError(
+                    'Material.additional_end_lines should be a '
+                    'dictionary where the keys are the name of the neutronics'
+                    'code. Acceptable values are {}'.format(string_codes))
+            if not isinstance(entries, list):
+                raise ValueError(
+                    'Material.additional_end_lines should be a'
+                    ' dictionary where the value of each dictionary entry is a'
+                    ' list')
+            for entry in entries:
+                if not isinstance(entry, str):
+                    raise ValueError(
+                        'Material.additional_end_lines should be'
+                        'a dictionary where the value of each dictionary entry'
+                        ' is a list of strings')
+    return value
+
+
 def add_additional_end_lines(code: str, mat) -> list:
     """
     Accertains if additional lines were requested by the user for the code used

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -13,6 +13,17 @@ except BaseException:
         "OpenMC not found, .openmc_material, .serpent_material, .mcnp_material,\
             .fispact_material not avaiable")
 
+def add_additional_end_lines(code: str, mat) -> list:
+    """
+    Accertains if additional lines were requested by the user for the code used
+    and if so returns the additional lines request as a list to be added to the
+    end of the existing material card list.
+    """
+    print(mat.additional_end_lines)
+    if mat.additional_end_lines is not None:
+        if code in list(mat.additional_end_lines.keys()):
+            return mat.additional_end_lines[code]
+    return []
 
 def make_fispact_material(mat) -> str:
     """
@@ -39,6 +50,8 @@ def make_fispact_material(mat) -> str:
         atoms_cm3 = atoms_barn_cm * 1.0e24
         atoms = mat.volume_in_cm3 * atoms_cm3
         mat_card.append(isotope + " " + "{:.12E}".format(atoms))
+
+    mat_card = mat_card + add_additional_end_lines('fispact', mat)
 
     return "\n".join(mat_card)
 
@@ -74,6 +87,8 @@ def make_serpent_material(mat) -> str:
             + prefix
             + f"{isotope[1]:.{mat.decimal_places}e}"
         )
+
+    mat_card = mat_card + add_additional_end_lines('serpent', mat)
 
     return "\n".join(mat_card)
 
@@ -124,6 +139,8 @@ def make_mcnp_material(mat) -> str:
 
         mat_card.append(start + rest)
 
+    mat_card = mat_card + add_additional_end_lines('mcnp', mat)
+
     return "\n".join(mat_card)
 
 
@@ -157,8 +174,11 @@ def make_shift_material(mat) -> str:
     for nuclide, atom_dens in mat.openmc_material.get_nuclide_atom_densities().items():
         zaid += ' ' + isotope_to_zaid(nuclide)
         nd_ += ' ' + f"{atom_dens[1]:.{mat.decimal_places}e}"
-
+    
     mat_card.extend([zaid, nd_])
+
+    mat_card = mat_card + add_additional_end_lines('shift', mat)
+
     return "\n".join(mat_card)
 
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -13,6 +13,7 @@ except BaseException:
         "OpenMC not found, .openmc_material, .serpent_material, .mcnp_material,\
             .fispact_material not avaiable")
 
+
 def add_additional_end_lines(code: str, mat) -> list:
     """
     Accertains if additional lines were requested by the user for the code used
@@ -24,6 +25,7 @@ def add_additional_end_lines(code: str, mat) -> list:
         if code in list(mat.additional_end_lines.keys()):
             return mat.additional_end_lines[code]
     return []
+
 
 def make_fispact_material(mat) -> str:
     """
@@ -174,7 +176,7 @@ def make_shift_material(mat) -> str:
     for nuclide, atom_dens in mat.openmc_material.get_nuclide_atom_densities().items():
         zaid += ' ' + isotope_to_zaid(nuclide)
         nd_ += ' ' + f"{atom_dens[1]:.{mat.decimal_places}e}"
-    
+
     mat_card.extend([zaid, nd_])
 
     mat_card = mat_card + add_additional_end_lines('shift', mat)

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.1.16",
+    version="0.2.0",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
-    author_email="jonathan.shimwell@ukaea.uk",
+    author_email="mail@jshimwell.com",
     description="A tool for making neutronics material cards for use in OpenMC, MCNP, Serpent, Shift and Fispact",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,106 @@ if __name__ == "__main__":
 
 
 class test_object_properties(unittest.TestCase):
+
+    def test_additional_lines_multimaterial_mcnp(self):
+
+        test_mat1 = nmm.Material(
+                        'Li4SiO4',
+                        additional_end_lines={'mcnp': ['mat1_additional']}
+        )
+        test_mat2 = nmm.Material(
+                        'Be12Ti',
+                        additional_end_lines={'mcnp': ['mat2_additional']}
+        )
+
+        test_mat3 = nmm.MultiMaterial(
+            material_tag='mixed',
+            materials=[test_mat1, test_mat2],
+            fracs=[0.5, 0.5],
+            material_id=3,
+            additional_end_lines={'mcnp': ['mat3_secret']}
+        )
+        test_mat3.mcnp_material
+
+        assert test_mat3.mcnp_material.split('\n')[-1] == 'mat3_secret'
+
+    def test_additional_lines_mcnp(self):
+
+        test_mat = nmm.Material(
+                        'H2O',
+                        pressure_in_Pa=1e6,
+                        temperature_in_C=20,
+                        material_id=1,
+                        additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
+        )
+        assert test_mat.mcnp_material.split('\n')[-1] == '        mt24 lwtr.01'
+
+    def test_additional_lines_shift(self):
+        test_mat = nmm.Material(
+                        'H2O',
+                        pressure_in_Pa=1e6,
+                        temperature_in_C=20,
+                        material_id=1,
+                        additional_end_lines={'shift': ['coucou']}
+        )
+        assert test_mat.shift_material.split('\n')[-1] == 'coucou'
+
+    def test_additional_lines_fispact(self):
+        test_mat = nmm.Material(
+                        'H2O',
+                        pressure_in_Pa=1e6,
+                        temperature_in_C=20,
+                        material_id=1,
+                        volume_in_cm3=1,
+                        additional_end_lines={'fispact': ['coucou']}
+        )
+        assert test_mat.fispact_material.split('\n')[-1] == 'coucou'
+
+    def test_additional_lines_serpent(self):
+        test_mat = nmm.Material(
+                        'H2O',
+                        pressure_in_Pa=1e6,
+                        temperature_in_C=20,
+                        material_id=1,
+                        additional_end_lines={'serpent': ['coucou']}
+        )
+        assert test_mat.serpent_material.split('\n')[-1] == 'coucou'
+
+    def test_additional_lines_from_json(self):
+        test_material_1 = {
+            "mat_with_add_line": {
+                "chemical_equation": "WC",
+                "material_id": 2,
+                "density": 18.0,
+                "density_unit": "g/cm3",
+                "percent_type": "ao",
+                "additional_end_lines": {'mcnp': ['coucou']}
+            }
+        }
+
+        with open("extra_material_1.json", "w") as outfile:
+            json.dump(test_material_1, outfile)
+
+        nmm.AddMaterialFromFile("extra_material_1.json")
+
+        test_mat = nmm.Material('mat_with_add_line')
+        assert test_mat.mcnp_material.split('\n')[-1] == 'coucou'
+
+    def test_incorrect_additional_lines_code_name(self):
+
+        def incorrect_additional_lines_code_name():
+            """Set merge_tolerance as a negative number which should raise an error"""
+
+            nmm.Material(
+                'Li4SiO4',
+                additional_end_lines={'unknow code': ['coucou']}
+            )
+
+        self.assertRaises(
+            ValueError,
+            incorrect_additional_lines_code_name
+        )
+
     def test_zaid_to_isotope(self):
         assert nmm.utils.zaid_to_isotope("3006") == "Li6"
         assert nmm.utils.zaid_to_isotope("03006") == "Li6"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,7 @@ class test_object_properties(unittest.TestCase):
                 'mcnp': ['extra_mcnp_lin'],
                 'serpent': ['extra_serpent_lin'],
                 'fispact': ['extra_fispact_lin'],
+                'shift': ['extra_shift_lin'],
             }
         )
         test_mat3.mcnp_material
@@ -45,6 +46,7 @@ class test_object_properties(unittest.TestCase):
         assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
         assert test_mat3.serpent_material.split('\n')[-1] == 'extra_serpent_lin'
         assert test_mat3.fispact_material.split('\n')[-1] == 'extra_fispact_lin'
+        assert test_mat3.shift_material.split('\n')[-1] == 'extra_shift_lin'
 
     def test_additional_lines_mcnp(self):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,12 +20,12 @@ class test_object_properties(unittest.TestCase):
     def test_additional_lines_multimaterial_mcnp(self):
 
         test_mat1 = nmm.Material(
-                        'Li4SiO4',
-                        additional_end_lines={'mcnp': ['mat1_additional']}
+            'Li4SiO4',
+            additional_end_lines={'mcnp': ['mat1_additional']}
         )
         test_mat2 = nmm.Material(
-                        'Be12Ti',
-                        additional_end_lines={'mcnp': ['mat2_additional']}
+            'Be12Ti',
+            additional_end_lines={'mcnp': ['mat2_additional']}
         )
 
         test_mat3 = nmm.MultiMaterial(
@@ -42,42 +42,42 @@ class test_object_properties(unittest.TestCase):
     def test_additional_lines_mcnp(self):
 
         test_mat = nmm.Material(
-                        'H2O',
-                        pressure_in_Pa=1e6,
-                        temperature_in_C=20,
-                        material_id=1,
-                        additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
+            'H2O',
+            pressure_in_Pa=1e6,
+            temperature_in_C=20,
+            material_id=1,
+            additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
         )
         assert test_mat.mcnp_material.split('\n')[-1] == '        mt24 lwtr.01'
 
     def test_additional_lines_shift(self):
         test_mat = nmm.Material(
-                        'H2O',
-                        pressure_in_Pa=1e6,
-                        temperature_in_C=20,
-                        material_id=1,
-                        additional_end_lines={'shift': ['coucou']}
+            'H2O',
+            pressure_in_Pa=1e6,
+            temperature_in_C=20,
+            material_id=1,
+            additional_end_lines={'shift': ['coucou']}
         )
         assert test_mat.shift_material.split('\n')[-1] == 'coucou'
 
     def test_additional_lines_fispact(self):
         test_mat = nmm.Material(
-                        'H2O',
-                        pressure_in_Pa=1e6,
-                        temperature_in_C=20,
-                        material_id=1,
-                        volume_in_cm3=1,
-                        additional_end_lines={'fispact': ['coucou']}
+            'H2O',
+            pressure_in_Pa=1e6,
+            temperature_in_C=20,
+            material_id=1,
+            volume_in_cm3=1,
+            additional_end_lines={'fispact': ['coucou']}
         )
         assert test_mat.fispact_material.split('\n')[-1] == 'coucou'
 
     def test_additional_lines_serpent(self):
         test_mat = nmm.Material(
-                        'H2O',
-                        pressure_in_Pa=1e6,
-                        temperature_in_C=20,
-                        material_id=1,
-                        additional_end_lines={'serpent': ['coucou']}
+            'H2O',
+            pressure_in_Pa=1e6,
+            temperature_in_C=20,
+            material_id=1,
+            additional_end_lines={'serpent': ['coucou']}
         )
         assert test_mat.serpent_material.split('\n')[-1] == 'coucou'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,7 +115,8 @@ class test_object_properties(unittest.TestCase):
     def test_incorrect_additional_lines_code_name(self):
 
         def incorrect_additional_lines_code_name():
-            """Set merge_tolerance as a negative number which should raise an error"""
+            """Set additional_end_lines to not the name of a neutronics code
+            which should raise an error"""
 
             nmm.Material(
                 'Li4SiO4',
@@ -125,6 +126,38 @@ class test_object_properties(unittest.TestCase):
         self.assertRaises(
             ValueError,
             incorrect_additional_lines_code_name
+        )
+
+    def test_incorrect_additional_lines_code_value_type(self):
+
+        def incorrect_additional_lines_code_value_type():
+            """Set additional_end_lines value to a string
+            which should raise an error"""
+
+            nmm.Material(
+                'Li4SiO4',
+                additional_end_lines={'unknow code': 'serpent'}
+            )
+
+        self.assertRaises(
+            ValueError,
+            incorrect_additional_lines_code_value_type
+        )
+
+    def test_incorrect_additional_lines_code_value_list_type(self):
+
+        def incorrect_additional_lines_code_value_list_type():
+            """Set additional_end_lines value to a list of ints
+            which should raise an error"""
+
+            nmm.Material(
+                'Li4SiO4',
+                additional_end_lines={'unknow code': [1]}
+            )
+
+        self.assertRaises(
+            ValueError,
+            incorrect_additional_lines_code_value_list_type
         )
 
     def test_zaid_to_isotope(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,6 @@ class test_object_properties(unittest.TestCase):
                 'shift': ['extra_shift_lin'],
             }
         )
-        test_mat3.mcnp_material
 
         assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
         assert test_mat3.serpent_material.split('\n')[-1] == 'extra_serpent_lin'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ class test_object_properties(unittest.TestCase):
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
-                "additional_end_lines": {'mcnp': ['coucou1','coucou2']}
+                "additional_end_lines": {'mcnp': ['coucou1', 'coucou2']}
             }
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ class test_object_properties(unittest.TestCase):
         test_mat3 = nmm.MultiMaterial(
             material_tag='mixed',
             materials=[test_mat1, test_mat2],
+            temperature_in_K=500,
             fracs=[0.5, 0.5],
             material_id=3,
             volume_in_cm3=1,
@@ -41,7 +42,6 @@ class test_object_properties(unittest.TestCase):
                 'shift': ['extra_shift_lin'],
             }
         )
-        test_mat3.mcnp_material
 
         assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
         assert test_mat3.serpent_material.split(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,8 +44,10 @@ class test_object_properties(unittest.TestCase):
         test_mat3.mcnp_material
 
         assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
-        assert test_mat3.serpent_material.split('\n')[-1] == 'extra_serpent_lin'
-        assert test_mat3.fispact_material.split('\n')[-1] == 'extra_fispact_lin'
+        assert test_mat3.serpent_material.split(
+            '\n')[-1] == 'extra_serpent_lin'
+        assert test_mat3.fispact_material.split(
+            '\n')[-1] == 'extra_fispact_lin'
         assert test_mat3.shift_material.split('\n')[-1] == 'extra_shift_lin'
 
     def test_additional_lines_mcnp(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,6 +164,41 @@ class test_object_properties(unittest.TestCase):
             incorrect_additional_lines_code_value_list_type
         )
 
+    def test_check_add_additional_end_lines_error_handeling(self):
+
+        def incorrect_type_dict():
+            """Set additional_end_lines value to a string which should raise an
+            error"""
+
+            nmm.utils.check_add_additional_end_lines('mcnp')
+
+        self.assertRaises(
+            ValueError,
+            incorrect_type_dict
+        )
+
+        def incorrect_type_dict_value_empty():
+            """Set additional_end_lines value to a string which should raise an
+            error"""
+
+            nmm.utils.check_add_additional_end_lines({'mcnp': 'random string'})
+
+        self.assertRaises(
+            ValueError,
+            incorrect_type_dict_value_empty
+        )
+
+        def incorrect_type_dict_value():
+            """Set additional_end_lines value to a list of ints which should
+            raise an error"""
+
+            nmm.utils.check_add_additional_end_lines({'mcnp': [1, 2, 3]})
+
+        self.assertRaises(
+            ValueError,
+            incorrect_type_dict_value
+        )
+
     def test_zaid_to_isotope(self):
         assert nmm.utils.zaid_to_isotope("3006") == "Li6"
         assert nmm.utils.zaid_to_isotope("03006") == "Li6"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,11 +33,18 @@ class test_object_properties(unittest.TestCase):
             materials=[test_mat1, test_mat2],
             fracs=[0.5, 0.5],
             material_id=3,
-            additional_end_lines={'mcnp': ['mat3_secret']}
+            volume_in_cm3=1,
+            additional_end_lines={
+                'mcnp': ['extra_mcnp_lin'],
+                'serpent': ['extra_serpent_lin'],
+                'fispact': ['extra_fispact_lin'],
+            }
         )
         test_mat3.mcnp_material
 
-        assert test_mat3.mcnp_material.split('\n')[-1] == 'mat3_secret'
+        assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
+        assert test_mat3.serpent_material.split('\n')[-1] == 'extra_serpent_lin'
+        assert test_mat3.fispact_material.split('\n')[-1] == 'extra_fispact_lin'
 
     def test_additional_lines_mcnp(self):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,9 @@ class test_object_properties(unittest.TestCase):
         assert test_mat.serpent_material.split('\n')[-1] == 'coucou'
 
     def test_additional_lines_from_json(self):
+        """
+        tests multiple additional lines are added to the mcnp material card
+        """
         test_material_1 = {
             "mat_with_add_line": {
                 "chemical_equation": "WC",
@@ -100,7 +103,7 @@ class test_object_properties(unittest.TestCase):
                 "density": 18.0,
                 "density_unit": "g/cm3",
                 "percent_type": "ao",
-                "additional_end_lines": {'mcnp': ['coucou']}
+                "additional_end_lines": {'mcnp': ['coucou1','coucou2']}
             }
         }
 
@@ -110,7 +113,8 @@ class test_object_properties(unittest.TestCase):
         nmm.AddMaterialFromFile("extra_material_1.json")
 
         test_mat = nmm.Material('mat_with_add_line')
-        assert test_mat.mcnp_material.split('\n')[-1] == 'coucou'
+        assert test_mat.mcnp_material.split('\n')[-2] == 'coucou1'
+        assert test_mat.mcnp_material.split('\n')[-1] == 'coucou2'
 
     def test_incorrect_additional_lines_code_name(self):
 


### PR DESCRIPTION
This adds the option to add additional lines to the end of a material card.

Useful for S(a,b) specification in MCNP and more general flexability

Todo

- [x] Examples in the documentation
