### PR TITLE
added temperature_to_neutronics_code flag

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -100,6 +100,16 @@ class Material:
             liquids such as lithium-lead and FLiBe that are used as breeder
             materials. Added to the openmc material object and the serpent
             material card.
+        temperature_to_neutronics_code: The temperature args are often used to
+            find the material density via density equations. However it can be
+            desirable to not make use of this temperature in the neutronics
+            codes. Typically this is due to missing cross section data. 
+            Defaults to True which makes use of any material temperature in the
+            neutronics material. Can be set to False which doesn't propagate
+            temperature data to the neutroics material. This only impacts
+            openmc and serpent materials. As shift materials require the use of
+            temperature and fispact/mcnp materials don't make use of
+            temperature on the material card.
         pressure_in_Pa: The pressure of the material in Pascals
             Pressure impacts the density of some materials in the
             collection. Materials in the collection that are impacted by
@@ -155,6 +165,7 @@ class Material:
         enrichment_target: Optional[str] = None,
         temperature_in_C: Optional[float] = None,
         temperature_in_K: Optional[float] = None,
+        temperature_to_neutronics_code: Optional[bool] = True,
         pressure_in_Pa: Optional[float] = None,
         elements: Optional[Dict[str, float]] = None,
         chemical_equation: Optional[str] = None,
@@ -178,6 +189,7 @@ class Material:
         self.material_tag = material_tag
         self.temperature_in_C = temperature_in_C
         self.temperature_in_K = temperature_in_K
+        self.temperature_to_neutronics_code = temperature_to_neutronics_code
         self.pressure_in_Pa = pressure_in_Pa
         self.packing_fraction = packing_fraction
         self.elements = elements
@@ -751,12 +763,13 @@ class Material:
         if self.material_id is not None:
             openmc_material = openmc.Material(
                 material_id=self.material_id,
-                name=name,
-                temperature=self.temperature_in_K)
+                name=name)
         else:
             openmc_material = openmc.Material(
-                name=name,
-                temperature=self.temperature_in_K)
+                name=name)
+
+        if self.temperature_to_neutronics_code is True:
+            openmc_material.temperature = self.temperature_in_K
 
         if self.isotopes is not None:
 

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -103,7 +103,7 @@ class Material:
         temperature_to_neutronics_code: The temperature args are often used to
             find the material density via density equations. However it can be
             desirable to not make use of this temperature in the neutronics
-            codes. Typically this is due to missing cross section data. 
+            codes. Typically this is due to missing cross section data.
             Defaults to True which makes use of any material temperature in the
             neutronics material. Can be set to False which doesn't propagate
             temperature data to the neutroics material. This only impacts

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -73,6 +73,16 @@ class MultiMaterial:
         temperature_in_K: The temperature of the material in degrees
             Kelvin. Added to the openmc material object and the serpent
             material card
+        temperature_to_neutronics_code: The temperature args are often used to
+            find the material density via density equations. However it can be
+            desirable to not make use of this temperature in the neutronics
+            codes. Typically this is due to missing cross section data. 
+            Defaults to True which makes use of any material temperature in the
+            neutronics material. Can be set to False which doesn't propagate
+            temperature data to the neutroics material. This only impacts
+            openmc and serpent materials. As shift materials require the use of
+            temperature and fispact/mcnp materials don't make use of
+            temperature on the material card.
         additional_end_lines: Additional lines of test that are added to the
             end of the material card. Compatable with MCNP, Serpent, Fispact
             outputs which are string based. Agument should be a dictionary
@@ -100,6 +110,7 @@ class MultiMaterial:
         volume_in_cm3: Optional[float] = None,
         temperature_in_C: Optional[float] = None,
         temperature_in_K: Optional[float] = None,
+        temperature_to_neutronics_code: Optional[bool] = True,
         additional_end_lines: Optional[Dict[str, List[str]]] = None,
     ):
         self.material_tag = material_tag
@@ -113,6 +124,7 @@ class MultiMaterial:
         self.volume_in_cm3 = volume_in_cm3
         self.temperature_in_C = temperature_in_C
         self.temperature_in_K = temperature_in_K
+        self.temperature_to_neutronics_code = temperature_to_neutronics_code
         self.additional_end_lines = additional_end_lines
 
         # derived values

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -76,7 +76,7 @@ class MultiMaterial:
         temperature_to_neutronics_code: The temperature args are often used to
             find the material density via density equations. However it can be
             desirable to not make use of this temperature in the neutronics
-            codes. Typically this is due to missing cross section data. 
+            codes. Typically this is due to missing cross section data.
             Defaults to True which makes use of any material temperature in the
             neutronics material. Can be set to False which doesn't propagate
             temperature data to the neutroics material. This only impacts

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -231,7 +231,7 @@ def make_serpent_material(mat) -> str:
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_to_neutronics_code is True:
         if mat.temperature_in_K is not None:
-            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' '
+            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K)
         # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -229,9 +229,10 @@ def make_serpent_material(mat) -> str:
 
     mat_card = ["mat " + name + " " +
                 str(mat.openmc_material.get_mass_density())]
-    if mat.temperature_in_K is not None:
-        mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' '
-    # should check if percent type is 'ao' or 'wo'
+    if mat.temperature_to_neutronics_code is True:
+        if mat.temperature_in_K is not None:
+            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' '
+        # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:
         if isotope[2] == "ao":

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -231,12 +231,7 @@ def make_serpent_material(mat) -> str:
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_to_neutronics_code is True:
         if mat.temperature_in_K is not None:
-<<<<<<< HEAD
             mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K)
-=======
-            mat_card[0] = mat_card[0] + ' tmp ' + \
-                str(mat.temperature_in_K) + ' '
->>>>>>> c31dd19ddb8db933ceb2dcd427555d4128f0ec1e
         # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -231,15 +231,17 @@ def make_serpent_material(mat) -> str:
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_to_neutronics_code is True:
         if mat.temperature_in_K is not None:
-<<<<<<< HEAD
-            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K)
-=======
-            mat_card[0] = mat_card[0] + ' tmp ' + \
-                str(mat.temperature_in_K) + ' '
->>>>>>> c31dd19ddb8db933ceb2dcd427555d4128f0ec1e
-        # should check if percent type is 'ao' or 'wo'
 
-    for isotope in mat.openmc_material.nuclides:
+
+<< << << < HEAD
+   mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K)
+== == == =
+   mat_card[0] = mat_card[0] + ' tmp ' + \
+        str(mat.temperature_in_K) + ' '
+>>>>>> > c31dd19ddb8db933ceb2dcd427555d4128f0ec1e
+       # should check if percent type is 'ao' or 'wo'
+
+   for isotope in mat.openmc_material.nuclides:
         if isotope[2] == "ao":
             prefix = "  "
         elif isotope[2] == "wo":

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -231,7 +231,8 @@ def make_serpent_material(mat) -> str:
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_to_neutronics_code is True:
         if mat.temperature_in_K is not None:
-            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K) + ' '
+            mat_card[0] = mat_card[0] + ' tmp ' + \
+                str(mat.temperature_in_K) + ' '
         # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -26,6 +26,26 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, error_raised_correctly)
 
+    def test_temperature_to_neutronics_code(self):
+        """Creates a material with a temperature and check that this can be
+        selectivly propagated to the openmc.material and that the density
+        remains unchanged"""
+
+        test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)
+
+        assert test_mat.temperature_in_K == 80
+        assert test_mat.openmc_material.temperature == 80
+
+        test_mat_2 = nmm.Material(
+            "FLiBe",
+            temperature_in_K=80,
+            pressure_in_Pa=1,
+            temperature_to_neutronics_code=False)
+
+        assert test_mat_2.temperature_in_K == 80
+        assert test_mat_2.openmc_material.temperature == None
+        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density     
+
     def test_density_of_material_is_set_from_equation(self):
         test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)
         assert test_mat.density is not None

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -4,12 +4,10 @@ __author__ = "neutronics material maker development team"
 
 
 import json
-import os
 import unittest
 
-import pytest
-
 import neutronics_material_maker as nmm
+import pytest
 
 
 class test_object_properties(unittest.TestCase):
@@ -26,9 +24,9 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, error_raised_correctly)
 
-    def test_temperature_to_neutronics_code(self):
+    def test_temperature_to_neutronics_code_openmc(self):
         """Creates a material with a temperature and check that this can be
-        selectivly propagated to the openmc.material and that the density
+        selectivly propagated to the openmc_material and that the density
         remains unchanged"""
 
         test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)
@@ -44,6 +42,28 @@ class test_object_properties(unittest.TestCase):
 
         assert test_mat_2.temperature_in_K == 80
         assert test_mat_2.openmc_material.temperature == None
+        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density 
+
+    def test_temperature_to_neutronics_code_serpent(self):
+        """Creates a material with a temperature and check that this can be
+        selectivly propagated to the serpent_material and that the density
+        remains unchanged"""
+
+        test_mat = nmm.Material("FLiBe", temperature_in_K=180, pressure_in_Pa=2)
+
+        assert test_mat.temperature_in_K == 180
+        assert test_mat.openmc_material.temperature == 180
+        assert test_mat.serpent_material.split('\n')[0].endswith(' tmp 180')
+
+        test_mat_2 = nmm.Material(
+            "FLiBe",
+            temperature_in_K=180,
+            pressure_in_Pa=1,
+            temperature_to_neutronics_code=False)
+
+        assert test_mat_2.temperature_in_K == 180
+        assert test_mat_2.openmc_material.temperature == None
+        assert test_mat_2.serpent_material.split('\n')[0].endswith(' tmp 180') is False
         assert test_mat.openmc_material.density == test_mat_2.openmc_material.density     
 
     def test_density_of_material_is_set_from_equation(self):

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -41,15 +41,18 @@ class test_object_properties(unittest.TestCase):
             temperature_to_neutronics_code=False)
 
         assert test_mat_2.temperature_in_K == 80
-        assert test_mat_2.openmc_material.temperature == None
-        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density 
+        assert test_mat_2.openmc_material.temperature is None
+        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
     def test_temperature_to_neutronics_code_serpent(self):
         """Creates a material with a temperature and check that this can be
         selectivly propagated to the serpent_material and that the density
         remains unchanged"""
 
-        test_mat = nmm.Material("FLiBe", temperature_in_K=180, pressure_in_Pa=2)
+        test_mat = nmm.Material(
+            "FLiBe",
+            temperature_in_K=180,
+            pressure_in_Pa=2)
 
         assert test_mat.temperature_in_K == 180
         assert test_mat.openmc_material.temperature == 180
@@ -62,9 +65,10 @@ class test_object_properties(unittest.TestCase):
             temperature_to_neutronics_code=False)
 
         assert test_mat_2.temperature_in_K == 180
-        assert test_mat_2.openmc_material.temperature == None
-        assert test_mat_2.serpent_material.split('\n')[0].endswith(' tmp 180') is False
-        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density     
+        assert test_mat_2.openmc_material.temperature is None
+        assert test_mat_2.serpent_material.split(
+            '\n')[0].endswith(' tmp 180') is False
+        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
     def test_density_of_material_is_set_from_equation(self):
         test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -43,8 +43,8 @@ class test_object_properties(unittest.TestCase):
             temperature_to_neutronics_code=False)
 
         assert test_mat_2.temperature_in_K == 80
-        assert test_mat_2.openmc_material.temperature == None
-        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density     
+        assert test_mat_2.openmc_material.temperature is None
+        assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
     def test_density_of_material_is_set_from_equation(self):
         test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)


### PR DESCRIPTION
This PR allows temperature information added to the Material object to be selectively propagated to the openmc_material

This is useful when one needs to use the temperature_in_K or  temperature_in_C to control the density but does not want the temperature setting in openmc (due to not having cross section data for temperatures)

example usage

```python
test_mat = nmm.Material(
    "FLiBe",
    temperature_in_K=80,
    pressure_in_Pa=1,
    temperature_to_neutronics_code=False
)
```

result
```python
print(test_mat.openmc_material.temperature)
>> None
``