### PR TITLE
Removing units from args

### DIFF
--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -51,7 +51,7 @@ For several materials within the collection the temperature and the pressure imp
 
     import neutronics_material_maker as nmm
 
-    my_mat1 = nmm.Material('H2O', temperature=300, pressure_in_Pa=15e6)
+    my_mat1 = nmm.Material('H2O', temperature=300, pressure=15e6)
 
     my_mat1.openmc_material
 
@@ -61,7 +61,7 @@ Temperature can be provided in degrees C or Kelvin.
 
     import neutronics_material_maker as nmm
 
-    my_mat1 = nmm.Material('H2O', temperature=573.15, pressure_in_Pa=15e6)
+    my_mat1 = nmm.Material('H2O', temperature=573.15, pressure=15e6)
 
     my_mat1.openmc_material
 
@@ -194,7 +194,7 @@ string.
         'H2O',
         material_id=24,
         temperature=573.15,
-        pressure_in_Pa=15e6,
+        pressure=15e6,
         additional_end_lines={'mcnp': ['      mt24 lwtr.01']}
     )
 

--- a/docs/source/example_material.rst
+++ b/docs/source/example_material.rst
@@ -38,7 +38,7 @@ a material id
 
 .. code-block:: python
 
-   my_mat = nmm.Material('eurofer', temperature_in_K=293, material_id=1)
+   my_mat = nmm.Material('eurofer', temperature=293, material_id=1)
    my_mat.shift_material
 
 
@@ -51,7 +51,7 @@ For several materials within the collection the temperature and the pressure imp
 
     import neutronics_material_maker as nmm
 
-    my_mat1 = nmm.Material('H2O', temperature_in_C=300, pressure_in_Pa=15e6)
+    my_mat1 = nmm.Material('H2O', temperature=300, pressure_in_Pa=15e6)
 
     my_mat1.openmc_material
 
@@ -61,14 +61,14 @@ Temperature can be provided in degrees C or Kelvin.
 
     import neutronics_material_maker as nmm
 
-    my_mat1 = nmm.Material('H2O', temperature_in_K=573.15, pressure_in_Pa=15e6)
+    my_mat1 = nmm.Material('H2O', temperature=573.15, pressure_in_Pa=15e6)
 
     my_mat1.openmc_material
 
-The temperature_in_K or the temperature_in_C is automatically sent to the
-openmc_material and serpent_material cards. However if this causes difficulties
-for you (perhaps due to not having cross sections at that temperature) this
-automatic propagate of temperature information can be disabled by setting the
+The temperature is automatically sent to the openmc_material and
+serpent_material cards. However if this causes difficulties for you (perhaps
+due to not having cross sections at that temperature) this automatic propagate
+of temperature information can be disabled by setting the 
 temperature_to_neutronics_code to False.
 
 
@@ -193,7 +193,7 @@ string.
     my_mat2 = nmm.Material(
         'H2O',
         material_id=24,
-        temperature_in_K=573.15,
+        temperature=573.15,
         pressure_in_Pa=15e6,
         additional_end_lines={'mcnp': ['      mt24 lwtr.01']}
     )

--- a/neutronics_material_maker/data/breeder_materials.json
+++ b/neutronics_material_maker/data/breeder_materials.json
@@ -1,7 +1,7 @@
 {
     "Li": {
         "chemical_equation": "Li",
-        "density_equation": "0.515 - 1.01e-4 * (temperature_in_C - 200)",
+        "density_equation": "0.515 - 1.01e-4 * (temperature + 273.15 - 200)",
         "density_unit": "g/cm3",
         "reference": "http://aries.ucsd.edu/LIB/PROPS/PANOS/li.html",
         "temperature_dependant": true,

--- a/neutronics_material_maker/data/coolant_materials.json
+++ b/neutronics_material_maker/data/coolant_materials.json
@@ -1,7 +1,7 @@
 {
     "He": {
         "elements": {"He": 1.0},
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'Helium')",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'Helium')",
         "density_unit": "kg/m3",
         "reference": "CoolProp python package for density equation",
         "temperature_dependant": true,
@@ -10,7 +10,7 @@
     },
     "H2O": {
         "chemical_equation": "H2O",
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'Water')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'Water')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -28,7 +28,7 @@
     },
     "CO2": {
         "chemical_equation": "CO2",
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'CO2')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'CO2')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -37,7 +37,7 @@
     },
     "nitrogen": {
         "chemical_equation": "N",
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'nitrogen')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'nitrogen')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -46,7 +46,7 @@
     },
     "argon": {
         "chemical_equation": "Ar",
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'argon')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'argon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -55,7 +55,7 @@
     },
     "xenon": {
         "chemical_equation": "Xe",
-        "density_equation": "PropsSI('D', 'T', temperature_in_K, 'P', pressure_in_Pa, 'xenon')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'xenon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,

--- a/neutronics_material_maker/data/coolant_materials.json
+++ b/neutronics_material_maker/data/coolant_materials.json
@@ -1,7 +1,7 @@
 {
     "He": {
         "elements": {"He": 1.0},
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'Helium')",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'Helium')",
         "density_unit": "kg/m3",
         "reference": "CoolProp python package for density equation",
         "temperature_dependant": true,
@@ -10,7 +10,7 @@
     },
     "H2O": {
         "chemical_equation": "H2O",
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'Water')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'Water')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -28,7 +28,7 @@
     },
     "CO2": {
         "chemical_equation": "CO2",
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'CO2')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'CO2')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -37,7 +37,7 @@
     },
     "nitrogen": {
         "chemical_equation": "N",
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'nitrogen')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'nitrogen')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -46,7 +46,7 @@
     },
     "argon": {
         "chemical_equation": "Ar",
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'argon')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'argon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,
@@ -55,7 +55,7 @@
     },
     "xenon": {
         "chemical_equation": "Xe",
-        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure_in_Pa, 'xenon')/1000.",
+        "density_equation": "PropsSI('D', 'T', temperature, 'P', pressure, 'xenon')/1000.",
         "density_unit": "g/cm3",
         "reference": "CoolProp python package",
         "temperature_dependant": true,

--- a/neutronics_material_maker/data/multiplier_and_breeder_materials.json
+++ b/neutronics_material_maker/data/multiplier_and_breeder_materials.json
@@ -1,7 +1,7 @@
 {
     "Pb842Li158": {
         "chemical_equation": "Pb842Li158",
-        "density_equation": "99.90*(0.1-16.8e-6*temperature_in_C)",
+        "density_equation": "99.90*(0.1-16.8e-6*(temperature + 273.15))",
         "density_unit": "g/cm3",
         "reference": "density equation valid for in the range 240-350 C. source http://aries.ucsd.edu/LIB/PROPS/PANOS/lipb.html",
         "temperature_dependant": true,
@@ -12,7 +12,7 @@
     },
     "lithium-lead": {
         "chemical_equation": "Pb842Li158",
-        "density_equation": "99.90*(0.1-16.8e-6*temperature_in_C)",
+        "density_equation": "99.90*(0.1-16.8e-6*(temperature + 273.15))",
         "density_unit": "g/cm3",
         "reference": "density equation valid for in the range 240-350 C. source http://aries.ucsd.edu/LIB/PROPS/PANOS/lipb.html",
         "temperature_dependant": true,
@@ -34,7 +34,7 @@
     },
     "FLiBe": {
         "chemical_equation": "F2Li2BeF2",
-        "density_equation": "2.214 - 4.2e-4 * temperature_in_C",
+        "density_equation": "2.214 - 4.2e-4 * (temperature + 273.15)",
         "density_unit": "g/cm3",
         "reference": "source http://aries.ucsd.edu/LIB/MEETINGS/0103-TRANSMUT/gohar/Gohar-present.pdf",
         "temperature_dependant": true,

--- a/neutronics_material_maker/data/multiplier_materials.json
+++ b/neutronics_material_maker/data/multiplier_materials.json
@@ -1,7 +1,7 @@
 {
     "Pb": {
         "chemical_equation": "Pb",
-        "density_equation": "10.678 - 13.174e-4 * (temperature_in_K-600.6)",
+        "density_equation": "10.678 - 13.174e-4 * (temperature-600.6)",
         "density_unit": "g/cm3",
         "reference": "https://www.sciencedirect.com/science/article/abs/pii/0022190261802261",
         "percent_type": "ao"

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -245,7 +245,8 @@ class Material:
                         "temperature is needed for", self.material_name
                     )
 
-            if "pressure_dependant" in material_dict[self.material_name].keys():
+            if "pressure_dependant" in material_dict[self.material_name].keys(
+            ):
                 if pressure is None:
                     raise ValueError(
                         "pressure is needed for",

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -54,7 +54,7 @@ class Material:
     collection of prepared materials. Modifiers to the material
     isotopes are applied according to arguments such
     as enrichment. Modifiers to the material density are applied
-    according to arguments like temperature and pressure_in_Pa
+    according to arguments like temperature and pressure
     where appropiate (gases, liquids). The collection of materials
     includes relationships between presure, temperature and density
     relationships. This allows the code to adjust the density of the
@@ -102,12 +102,11 @@ class Material:
             openmc and serpent materials. As shift materials require the use of
             temperature and fispact/mcnp materials don't make use of
             temperature on the material card.
-        pressure_in_Pa: The pressure of the material in Pascals
-            Pressure impacts the density of some materials in the
-            collection. Materials in the collection that are impacted by
-            pressure have density equations that depend on pressure.
-            These tend to be liquids and gases used for coolants such as
-            H2O and CO2.
+        pressure: The pressure of the material in Pascals. Pressure impacts the
+            density of some materials in the collection. Materials in the
+            collection that are impacted by pressure have density equations
+            that depend on pressure. These tend to be liquids and gases used
+            for coolants such as H2O and CO2.
         zaid_suffix: The nuclear library to apply to the zaid, for
             example ".31c", this is used in MCNP and Serpent material cards.
         material_id: the id number or mat number used in the MCNP material card
@@ -157,7 +156,7 @@ class Material:
         enrichment_target: Optional[str] = None,
         temperature: Optional[float] = None,
         temperature_to_neutronics_code: Optional[bool] = True,
-        pressure_in_Pa: Optional[float] = None,
+        pressure: Optional[float] = None,
         elements: Optional[Dict[str, float]] = None,
         chemical_equation: Optional[str] = None,
         isotopes: Optional[Dict[str, float]] = None,
@@ -180,7 +179,7 @@ class Material:
         self.material_tag = material_tag
         self.temperature = temperature
         self.temperature_to_neutronics_code = temperature_to_neutronics_code
-        self.pressure_in_Pa = pressure_in_Pa
+        self.pressure = pressure
         self.packing_fraction = packing_fraction
         self.elements = elements
         self.chemical_equation = chemical_equation
@@ -247,9 +246,9 @@ class Material:
                     )
 
             if "pressure_dependant" in material_dict[self.material_name].keys():
-                if pressure_in_Pa is None:
+                if pressure is None:
                     raise ValueError(
-                        "pressure_in_Pa is needed for",
+                        "pressure is needed for",
                         self.material_name)
 
         # this populates the density of materials when density is provided by
@@ -622,23 +621,23 @@ class Material:
         self._enrichment_target = value
 
     @property
-    def pressure_in_Pa(self):
+    def pressure(self):
         """
         The pressure of the material in Pascals. Must be a possive number. Used
         to calculate the density if the density_equation contains
-        pressure_in_Pa.
+        pressure.
 
         :type: float
         """
-        return self._pressure_in_Pa
+        return self._pressure
 
-    @pressure_in_Pa.setter
-    def pressure_in_Pa(self, value):
+    @pressure.setter
+    def pressure(self, value):
         if value is not None:
             if value < 0.0:
                 raise ValueError(
-                    "Material.pressure_in_Pa must be greater than 0")
-        self._pressure_in_Pa = value
+                    "Material.pressure must be greater than 0")
+        self._pressure = value
 
     @property
     def reference(self):
@@ -793,10 +792,10 @@ class Material:
             ]
 
         if (
-            self.pressure_in_Pa is None
-            and "pressure_in_Pa" in material_dict[self.material_name].keys()
+            self.pressure is None
+            and "pressure" in material_dict[self.material_name].keys()
         ):
-            self.pressure_in_Pa = material_dict[self.material_name]["pressure_in_Pa"]
+            self.pressure = material_dict[self.material_name]["pressure"]
 
         if (
             self.packing_fraction is None
@@ -974,7 +973,7 @@ class Material:
 
                 # Potentially used in the eval part
                 aeval.symtable["temperature"] = self.temperature
-                aeval.symtable["pressure_in_Pa"] = self.pressure_in_Pa
+                aeval.symtable["pressure"] = self.pressure
 
                 density = aeval.eval(self.density_equation)
 
@@ -1046,7 +1045,7 @@ class Material:
             "material_name": self.material_name,
             "material_tag": self.material_tag,
             "temperature": self.temperature,
-            "pressure_in_Pa": self.pressure_in_Pa,
+            "pressure": self.pressure,
             "packing_fraction": self.packing_fraction,
             "elements": self.elements,
             "chemical_equation": self.chemical_equation,

--- a/neutronics_material_maker/mutlimaterial.py
+++ b/neutronics_material_maker/mutlimaterial.py
@@ -312,7 +312,7 @@ class MultiMaterial:
                     "material_name": material.material_name,
                     "material_tag": material.material_tag,
                     "temperature": material.temperature,
-                    "pressure_in_Pa": material.pressure_in_Pa,
+                    "pressure": material.pressure,
                     "packing_fraction": material.packing_fraction,
                     "elements": material.elements,
                     "chemical_equation": material.chemical_equation,

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -230,8 +230,8 @@ def make_serpent_material(mat) -> str:
     mat_card = ["mat " + name + " " +
                 str(mat.openmc_material.get_mass_density())]
     if mat.temperature_to_neutronics_code is True:
-        if mat.temperature_in_K is not None:
-            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature_in_K)
+        if mat.temperature is not None:
+            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature)
         # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:
@@ -310,9 +310,9 @@ def make_shift_material(mat) -> str:
         raise ValueError(
             "Material.material_id needs setting before shift_material can be made"
         )
-    if mat.temperature_in_K is None:
+    if mat.temperature is None:
         raise ValueError(
-            "Material.temperature_in_K needs setting before shift_material can be made"
+            "Material.temperature needs setting before shift_material can be made"
         )
 
     if mat.material_tag is None:
@@ -324,7 +324,7 @@ def make_shift_material(mat) -> str:
         "[COMP][MATERIAL]\n"
         + "name %s\n" % name
         + "matid %s\n" % mat.material_id
-        + "tmp %s" % mat.temperature_in_K
+        + "tmp %s" % mat.temperature
     ]
     zaid = 'zaid'
     nd_ = 'nd'

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -29,18 +29,18 @@ class test_object_properties(unittest.TestCase):
         selectivly propagated to the openmc_material and that the density
         remains unchanged"""
 
-        test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)
+        test_mat = nmm.Material("FLiBe", temperature=80, pressure_in_Pa=1)
 
-        assert test_mat.temperature_in_K == 80
+        assert test_mat.temperature == 80
         assert test_mat.openmc_material.temperature == 80
 
         test_mat_2 = nmm.Material(
             "FLiBe",
-            temperature_in_K=80,
+            temperature=80,
             pressure_in_Pa=1,
             temperature_to_neutronics_code=False)
 
-        assert test_mat_2.temperature_in_K == 80
+        assert test_mat_2.temperature == 80
         assert test_mat_2.openmc_material.temperature is None
         assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
@@ -51,27 +51,27 @@ class test_object_properties(unittest.TestCase):
 
         test_mat = nmm.Material(
             "FLiBe",
-            temperature_in_K=180,
+            temperature=180,
             pressure_in_Pa=2)
 
-        assert test_mat.temperature_in_K == 180
+        assert test_mat.temperature == 180
         assert test_mat.openmc_material.temperature == 180
         assert test_mat.serpent_material.split('\n')[0].endswith(' tmp 180')
 
         test_mat_2 = nmm.Material(
             "FLiBe",
-            temperature_in_K=180,
+            temperature=180,
             pressure_in_Pa=1,
             temperature_to_neutronics_code=False)
 
-        assert test_mat_2.temperature_in_K == 180
+        assert test_mat_2.temperature == 180
         assert test_mat_2.openmc_material.temperature is None
         assert test_mat_2.serpent_material.split(
             '\n')[0].endswith(' tmp 180') is False
         assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
     def test_density_of_material_is_set_from_equation(self):
-        test_mat = nmm.Material("FLiBe", temperature_in_K=80, pressure_in_Pa=1)
+        test_mat = nmm.Material("FLiBe", temperature=80, pressure_in_Pa=1)
         assert test_mat.density is not None
 
     def test_density_of_material_is_set_from_crystal(self):
@@ -398,7 +398,7 @@ class test_object_properties(unittest.TestCase):
             enrichment_target="Li6",
             enrichment_type="ao",
             chemical_equation=lithium_lead_elements,
-            temperature_in_C=450,
+            temperature=450,
         )
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
@@ -445,7 +445,7 @@ class test_object_properties(unittest.TestCase):
             enrichment_target="Li6",
             enrichment_type="ao",
             chemical_equation=lithium_lead_elements,
-            temperature_in_C=450,
+            temperature=450,
         )
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
@@ -552,7 +552,7 @@ class test_object_properties(unittest.TestCase):
         test_material = nmm.Material(
             "lithium-lead",
             chemical_equation=lithium_lead_elements,
-            temperature_in_C=450,
+            temperature=450,
         )
         nucs = test_material.openmc_material.nuclides
         pb_atom_count = 0
@@ -586,23 +586,23 @@ class test_object_properties(unittest.TestCase):
         def incorrect_pressure_in_Pa():
             """checks a ValueError is raised when pressure_in_Pa is below 0"""
 
-            nmm.Material("H2O", temperature_in_C=10, pressure_in_Pa=-1e6)
+            nmm.Material("H2O", temperature=283, pressure_in_Pa=-1e6)
 
         self.assertRaises(ValueError, incorrect_pressure_in_Pa)
 
-        def incorrect_temperature_in_K():
-            """checks a ValueError is raised when temperature_in_K is below 0"""
+        def incorrect_temperature():
+            """checks a ValueError is raised when temperature is below 0"""
 
-            nmm.Material("H2O", temperature_in_K=-10, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature=-10, pressure_in_Pa=1e6)
 
-        self.assertRaises(ValueError, incorrect_temperature_in_K)
+        self.assertRaises(ValueError, incorrect_temperature)
 
-        def incorrect_temperature_in_C():
-            """checks a ValueError is raised when temperature_in_C is below absolute zero"""
+        def incorrect_temperature_too_low():
+            """checks a ValueError is raised when temperature is below absolute zero"""
 
-            nmm.Material("H2O", temperature_in_C=-300, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature=-1, pressure_in_Pa=1e6)
 
-        self.assertRaises(ValueError, incorrect_temperature_in_C)
+        self.assertRaises(ValueError, incorrect_temperature_too_low)
 
         def incorrect_elements_chemical_equation_usage():
             """checks a ValueError is raised when the both chemical_equation and elements are used"""
@@ -665,7 +665,7 @@ class test_object_properties(unittest.TestCase):
             """checks a ValueError is raised when the temperature is not set"""
 
             test_material = nmm.Material("H2O",
-                                         temperature_in_C=10,
+                                         temperature=283,
                                          pressure_in_Pa=-1e6)
             test_material.material_name = 1
 
@@ -719,23 +719,14 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, test_incorrect_volume_of_unit_cell_cm3)
 
-        def test_incorrect_temperature_in_c():
+        def test_incorrect_temperature():
             """checks a ValueError is raised when the temperature is not set"""
 
             nmm.Material(
                 "eurofer",
-                temperature_in_C=-1000.)
+                temperature=-1.)
 
-        self.assertRaises(ValueError, test_incorrect_temperature_in_c)
-
-        def test_incorrect_temperature_in_k():
-            """checks a ValueError is raised when the temperature is not set"""
-
-            nmm.Material(
-                "eurofer",
-                temperature_in_K=-1.)
-
-        self.assertRaises(ValueError, test_incorrect_temperature_in_k)
+        self.assertRaises(ValueError, test_incorrect_temperature)
 
         def test_incorrect_zaid_suffix_type():
             """checks a ValueError is raised when the temperature is not set"""
@@ -960,12 +951,12 @@ class test_object_properties(unittest.TestCase):
 
     def test_json_dump_works(self):
         test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure_in_Pa=1e6)
         assert isinstance(json.dumps(test_material), str)
 
     def test_json_dump_contains_correct_keys(self):
         test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert "atoms_per_unit_cell" in test_material_in_json_form.keys()
@@ -983,17 +974,17 @@ class test_object_properties(unittest.TestCase):
         assert "percent_type" in test_material_in_json_form.keys()
         assert "pressure_in_Pa" in test_material_in_json_form.keys()
         assert "reference" in test_material_in_json_form.keys()
-        assert "temperature_in_C" in test_material_in_json_form.keys()
-        assert "temperature_in_K" in test_material_in_json_form.keys()
+        assert "temperature" in test_material_in_json_form.keys()
+        assert "temperature" in test_material_in_json_form.keys()
         assert "volume_of_unit_cell_cm3" in test_material_in_json_form.keys()
 
     def test_json_dump_contains_correct_values(self):
         test_material = nmm.Material(
-            "H2O", temperature_in_C=100, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure_in_Pa=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert test_material_in_json_form["pressure_in_Pa"] == 1e6
-        assert test_material_in_json_form["temperature_in_C"] == 100
+        assert test_material_in_json_form["temperature"] == 373
         assert test_material_in_json_form["material_name"] == "H2O"
 
     def test_temperature_from_C_in_materials(self):
@@ -1002,17 +993,16 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.Material(
             'H2O',
-            temperature_in_C=10,
+            temperature=383,
             pressure_in_Pa=15.5e6
         )
 
-        assert test_material.temperature_in_K == 283.15
-        assert test_material.temperature_in_C == 10
-        assert test_material.openmc_material.temperature == 283.15
+        assert test_material.temperature == 383
+        assert test_material.openmc_material.temperature == 383
 
         line_by_line_material = test_material.serpent_material.split("\n")
 
-        assert line_by_line_material[0].split()[-1] == "283.15"
+        assert line_by_line_material[0].split()[-1] == "383"
         assert line_by_line_material[0].split()[-2] == "tmp"
 
     def test_temperature_from_K_in_materials(self):
@@ -1021,12 +1011,11 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.Material(
             'H2O',
-            temperature_in_K=300,
+            temperature=300,
             pressure_in_Pa=15.5e6
         )
 
-        assert test_material.temperature_in_K == 300
-        assert test_material.temperature_in_C == pytest.approx(26.85)
+        assert test_material.temperature == 300
         assert test_material.openmc_material.temperature == 300
 
         line_by_line_material = test_material.serpent_material.split("\n")
@@ -1052,7 +1041,7 @@ class test_object_properties(unittest.TestCase):
         with pytest.raises(NameError):
             nmm.Material(
                 "BadMaterial",
-                temperature_in_C=100,
+                temperature=373,
                 pressure_in_Pa=1e6,
                 density_equation="os.system('ls')"
             )

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -29,7 +29,7 @@ class test_object_properties(unittest.TestCase):
         selectivly propagated to the openmc_material and that the density
         remains unchanged"""
 
-        test_mat = nmm.Material("FLiBe", temperature=80, pressure_in_Pa=1)
+        test_mat = nmm.Material("FLiBe", temperature=80, pressure=1)
 
         assert test_mat.temperature == 80
         assert test_mat.openmc_material.temperature == 80
@@ -37,7 +37,7 @@ class test_object_properties(unittest.TestCase):
         test_mat_2 = nmm.Material(
             "FLiBe",
             temperature=80,
-            pressure_in_Pa=1,
+            pressure=1,
             temperature_to_neutronics_code=False)
 
         assert test_mat_2.temperature == 80
@@ -52,7 +52,7 @@ class test_object_properties(unittest.TestCase):
         test_mat = nmm.Material(
             "FLiBe",
             temperature=180,
-            pressure_in_Pa=2)
+            pressure=2)
 
         assert test_mat.temperature == 180
         assert test_mat.openmc_material.temperature == 180
@@ -61,7 +61,7 @@ class test_object_properties(unittest.TestCase):
         test_mat_2 = nmm.Material(
             "FLiBe",
             temperature=180,
-            pressure_in_Pa=1,
+            pressure=1,
             temperature_to_neutronics_code=False)
 
         assert test_mat_2.temperature == 180
@@ -71,7 +71,7 @@ class test_object_properties(unittest.TestCase):
         assert test_mat.openmc_material.density == test_mat_2.openmc_material.density
 
     def test_density_of_material_is_set_from_equation(self):
-        test_mat = nmm.Material("FLiBe", temperature=80, pressure_in_Pa=1)
+        test_mat = nmm.Material("FLiBe", temperature=80, pressure=1)
         assert test_mat.density is not None
 
     def test_density_of_material_is_set_from_crystal(self):
@@ -583,24 +583,24 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, enrichment_too_low)
 
-        def incorrect_pressure_in_Pa():
-            """checks a ValueError is raised when pressure_in_Pa is below 0"""
+        def incorrect_pressure():
+            """checks a ValueError is raised when pressure is below 0"""
 
-            nmm.Material("H2O", temperature=283, pressure_in_Pa=-1e6)
+            nmm.Material("H2O", temperature=283, pressure=-1e6)
 
-        self.assertRaises(ValueError, incorrect_pressure_in_Pa)
+        self.assertRaises(ValueError, incorrect_pressure)
 
         def incorrect_temperature():
             """checks a ValueError is raised when temperature is below 0"""
 
-            nmm.Material("H2O", temperature=-10, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature=-10, pressure=1e6)
 
         self.assertRaises(ValueError, incorrect_temperature)
 
         def incorrect_temperature_too_low():
             """checks a ValueError is raised when temperature is below absolute zero"""
 
-            nmm.Material("H2O", temperature=-1, pressure_in_Pa=1e6)
+            nmm.Material("H2O", temperature=-1, pressure=1e6)
 
         self.assertRaises(ValueError, incorrect_temperature_too_low)
 
@@ -636,7 +636,7 @@ class test_object_properties(unittest.TestCase):
 
             nmm.Material(
                 material_name="He",
-                pressure_in_Pa=1e6,
+                pressure=1e6,
             )
 
         self.assertRaises(ValueError, test_missing_temperature_He)
@@ -646,7 +646,7 @@ class test_object_properties(unittest.TestCase):
 
             nmm.Material(
                 material_name="H2O",
-                pressure_in_Pa=1e6,
+                pressure=1e6,
             )
 
         self.assertRaises(ValueError, test_missing_temperature_H2O)
@@ -656,7 +656,7 @@ class test_object_properties(unittest.TestCase):
 
             nmm.Material(
                 material_name="CO2",
-                pressure_in_Pa=1e6,
+                pressure=1e6,
             )
 
         self.assertRaises(ValueError, test_missing_temperature_CO2)
@@ -666,7 +666,7 @@ class test_object_properties(unittest.TestCase):
 
             test_material = nmm.Material("H2O",
                                          temperature=283,
-                                         pressure_in_Pa=-1e6)
+                                         pressure=-1e6)
             test_material.material_name = 1
 
         self.assertRaises(ValueError, test_incorrect_material_name_type)
@@ -805,16 +805,16 @@ class test_object_properties(unittest.TestCase):
 
         self.assertRaises(ValueError, test_enrichment_too_low)
 
-        def test_pressure_in_Pa_too_low():
-            """checks a ValueError is raised when the pressure_in_Pa is the
+        def test_pressure_too_low():
+            """checks a ValueError is raised when the pressure is the
             too small"""
 
             nmm.Material(
                 "Li4SiO4",
-                pressure_in_Pa=-1
+                pressure=-1
             )
 
-        self.assertRaises(ValueError, test_pressure_in_Pa_too_low)
+        self.assertRaises(ValueError, test_pressure_too_low)
 
         def test_reference_wrong_type():
             """checks a ValueError is raised when the reference is the
@@ -951,12 +951,12 @@ class test_object_properties(unittest.TestCase):
 
     def test_json_dump_works(self):
         test_material = nmm.Material(
-            "H2O", temperature=373, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure=1e6)
         assert isinstance(json.dumps(test_material), str)
 
     def test_json_dump_contains_correct_keys(self):
         test_material = nmm.Material(
-            "H2O", temperature=373, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure=1e6)
         test_material_in_json_form = test_material.to_json()
 
         assert "atoms_per_unit_cell" in test_material_in_json_form.keys()
@@ -972,7 +972,7 @@ class test_object_properties(unittest.TestCase):
         assert "material_tag" in test_material_in_json_form.keys()
         assert "packing_fraction" in test_material_in_json_form.keys()
         assert "percent_type" in test_material_in_json_form.keys()
-        assert "pressure_in_Pa" in test_material_in_json_form.keys()
+        assert "pressure" in test_material_in_json_form.keys()
         assert "reference" in test_material_in_json_form.keys()
         assert "temperature" in test_material_in_json_form.keys()
         assert "temperature" in test_material_in_json_form.keys()
@@ -980,10 +980,10 @@ class test_object_properties(unittest.TestCase):
 
     def test_json_dump_contains_correct_values(self):
         test_material = nmm.Material(
-            "H2O", temperature=373, pressure_in_Pa=1e6)
+            "H2O", temperature=373, pressure=1e6)
         test_material_in_json_form = test_material.to_json()
 
-        assert test_material_in_json_form["pressure_in_Pa"] == 1e6
+        assert test_material_in_json_form["pressure"] == 1e6
         assert test_material_in_json_form["temperature"] == 373
         assert test_material_in_json_form["material_name"] == "H2O"
 
@@ -994,7 +994,7 @@ class test_object_properties(unittest.TestCase):
         test_material = nmm.Material(
             'H2O',
             temperature=383,
-            pressure_in_Pa=15.5e6
+            pressure=15.5e6
         )
 
         assert test_material.temperature == 383
@@ -1012,7 +1012,7 @@ class test_object_properties(unittest.TestCase):
         test_material = nmm.Material(
             'H2O',
             temperature=300,
-            pressure_in_Pa=15.5e6
+            pressure=15.5e6
         )
 
         assert test_material.temperature == 300
@@ -1042,7 +1042,7 @@ class test_object_properties(unittest.TestCase):
             nmm.Material(
                 "BadMaterial",
                 temperature=373,
-                pressure_in_Pa=1e6,
+                pressure=1e6,
                 density_equation="os.system('ls')"
             )
 

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -204,7 +204,7 @@ class test_object_properties(unittest.TestCase):
     def test_density_of_mixed_materials_from_density_equation(self):
 
         test_material = nmm.Material(
-            "H2O", temperature=300, pressure_in_Pa=100000)
+            "H2O", temperature=300, pressure=100000)
         test_mixed_material = nmm.MultiMaterial(
             material_tag="test_mixed_material",
             materials=[test_material],
@@ -217,7 +217,7 @@ class test_object_properties(unittest.TestCase):
     def test_density_of_mixed_one_packed_crystal_and_one_non_crystal(self):
 
         test_material_1 = nmm.Material(
-            material_name="H2O", temperature=300, pressure_in_Pa=100000
+            material_name="H2O", temperature=300, pressure=100000
         )
 
         test_material_2 = nmm.Material(material_name="Li4SiO4")

--- a/tests/test_Multmaterial.py
+++ b/tests/test_Multmaterial.py
@@ -44,7 +44,7 @@ class test_object_properties(unittest.TestCase):
             materials=[nmm.Material("Li4SiO4"), nmm.Material("Be12Ti")],
             fracs=[0.50, 0.50],
             percent_type="vo",
-            temperature_in_K=300,
+            temperature=300,
             material_id=2,
         )
 
@@ -99,7 +99,7 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.MultiMaterial(
             materials=[
-                nmm.Material('Pb842Li158', temperature_in_K=500),
+                nmm.Material('Pb842Li158', temperature=500),
                 nmm.Material('SiC')
             ],
             fracs=[0.5, 0.5])
@@ -113,7 +113,7 @@ class test_object_properties(unittest.TestCase):
 
         test_material = nmm.MultiMaterial(
             materials=[
-                nmm.Material('Pb842Li158', temperature_in_K=500),
+                nmm.Material('Pb842Li158', temperature=500),
                 nmm.Material('SiC')
             ],
             fracs=[0.5, 0.5],
@@ -204,7 +204,7 @@ class test_object_properties(unittest.TestCase):
     def test_density_of_mixed_materials_from_density_equation(self):
 
         test_material = nmm.Material(
-            "H2O", temperature_in_C=25, pressure_in_Pa=100000)
+            "H2O", temperature=300, pressure_in_Pa=100000)
         test_mixed_material = nmm.MultiMaterial(
             material_tag="test_mixed_material",
             materials=[test_material],
@@ -217,7 +217,7 @@ class test_object_properties(unittest.TestCase):
     def test_density_of_mixed_one_packed_crystal_and_one_non_crystal(self):
 
         test_material_1 = nmm.Material(
-            material_name="H2O", temperature_in_C=25, pressure_in_Pa=100000
+            material_name="H2O", temperature=300, pressure_in_Pa=100000
         )
 
         test_material_2 = nmm.Material(material_name="Li4SiO4")
@@ -550,11 +550,10 @@ class test_object_properties(unittest.TestCase):
                 nmm.Material("eurofer"),
             ],
             fracs=[0.3, 0.7],
-            temperature_in_C=10
+            temperature=283.15
         )
 
-        assert test_material.temperature_in_K == 283.15
-        assert test_material.temperature_in_C == 10
+        assert test_material.temperature == 283.15
         assert test_material.openmc_material.temperature == 283.15
 
         line_by_line_material = test_material.serpent_material.split("\n")
@@ -573,11 +572,10 @@ class test_object_properties(unittest.TestCase):
                 nmm.Material("eurofer"),
             ],
             fracs=[0.3, 0.7],
-            temperature_in_K=300
+            temperature=300
         )
 
-        assert test_material.temperature_in_K == 300
-        assert test_material.temperature_in_C == pytest.approx(26.85)
+        assert test_material.temperature == 300
         assert test_material.openmc_material.temperature == 300
 
         line_by_line_material = test_material.serpent_material.split("\n")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,7 +54,7 @@ class test_object_properties(unittest.TestCase):
 
         test_mat = nmm.Material(
             'H2O',
-            pressure_in_Pa=1e6,
+            pressure=1e6,
             temperature=393,
             material_id=1,
             additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
@@ -64,7 +64,7 @@ class test_object_properties(unittest.TestCase):
     def test_additional_lines_shift(self):
         test_mat = nmm.Material(
             'H2O',
-            pressure_in_Pa=1e6,
+            pressure=1e6,
             temperature=393,
             material_id=1,
             additional_end_lines={'shift': ['coucou']}
@@ -74,7 +74,7 @@ class test_object_properties(unittest.TestCase):
     def test_additional_lines_fispact(self):
         test_mat = nmm.Material(
             'H2O',
-            pressure_in_Pa=1e6,
+            pressure=1e6,
             temperature=393,
             material_id=1,
             volume_in_cm3=1,
@@ -85,7 +85,7 @@ class test_object_properties(unittest.TestCase):
     def test_additional_lines_serpent(self):
         test_mat = nmm.Material(
             'H2O',
-            pressure_in_Pa=1e6,
+            pressure=1e6,
             temperature=393,
             material_id=1,
             additional_end_lines={'serpent': ['coucou']}
@@ -257,7 +257,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature=300, pressure_in_Pa=5e6)
+                mat, temperature=300, pressure=5e6)
 
             assert isinstance(test_mat.openmc_material, openmc.Material)
 
@@ -266,7 +266,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature=300, pressure_in_Pa=5e6, material_id=1
+                mat, temperature=300, pressure=5e6, material_id=1
             )
 
             assert isinstance(test_mat.mcnp_material, str)
@@ -276,7 +276,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature=300, pressure_in_Pa=5e6, material_id=1
+                mat, temperature=300, pressure=5e6, material_id=1
             )
 
             assert isinstance(test_mat.shift_material, str)
@@ -288,7 +288,7 @@ class test_object_properties(unittest.TestCase):
             test_mat = nmm.Material(
                 mat,
                 temperature=300,
-                pressure_in_Pa=5e6,
+                pressure=5e6,
                 volume_in_cm3=1.5)
 
             assert isinstance(test_mat.fispact_material, str)
@@ -298,7 +298,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature=300, pressure_in_Pa=5e6)
+                mat, temperature=300, pressure=5e6)
 
             assert isinstance(test_mat.serpent_material, str)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ class test_object_properties(unittest.TestCase):
         test_mat3 = nmm.MultiMaterial(
             material_tag='mixed',
             materials=[test_mat1, test_mat2],
-            temperature_in_K=500,
+            temperature=500,
             fracs=[0.5, 0.5],
             material_id=3,
             volume_in_cm3=1,
@@ -55,7 +55,7 @@ class test_object_properties(unittest.TestCase):
         test_mat = nmm.Material(
             'H2O',
             pressure_in_Pa=1e6,
-            temperature_in_C=20,
+            temperature=393,
             material_id=1,
             additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
         )
@@ -65,7 +65,7 @@ class test_object_properties(unittest.TestCase):
         test_mat = nmm.Material(
             'H2O',
             pressure_in_Pa=1e6,
-            temperature_in_C=20,
+            temperature=393,
             material_id=1,
             additional_end_lines={'shift': ['coucou']}
         )
@@ -75,7 +75,7 @@ class test_object_properties(unittest.TestCase):
         test_mat = nmm.Material(
             'H2O',
             pressure_in_Pa=1e6,
-            temperature_in_C=20,
+            temperature=393,
             material_id=1,
             volume_in_cm3=1,
             additional_end_lines={'fispact': ['coucou']}
@@ -86,7 +86,7 @@ class test_object_properties(unittest.TestCase):
         test_mat = nmm.Material(
             'H2O',
             pressure_in_Pa=1e6,
-            temperature_in_C=20,
+            temperature=393,
             material_id=1,
             additional_end_lines={'serpent': ['coucou']}
         )
@@ -257,7 +257,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature_in_K=300, pressure_in_Pa=5e6)
+                mat, temperature=300, pressure_in_Pa=5e6)
 
             assert isinstance(test_mat.openmc_material, openmc.Material)
 
@@ -266,7 +266,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature_in_K=300, pressure_in_Pa=5e6, material_id=1
+                mat, temperature=300, pressure_in_Pa=5e6, material_id=1
             )
 
             assert isinstance(test_mat.mcnp_material, str)
@@ -276,7 +276,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature_in_K=300, pressure_in_Pa=5e6, material_id=1
+                mat, temperature=300, pressure_in_Pa=5e6, material_id=1
             )
 
             assert isinstance(test_mat.shift_material, str)
@@ -287,7 +287,7 @@ class test_object_properties(unittest.TestCase):
             print(mat)
             test_mat = nmm.Material(
                 mat,
-                temperature_in_K=300,
+                temperature=300,
                 pressure_in_Pa=5e6,
                 volume_in_cm3=1.5)
 
@@ -298,7 +298,7 @@ class test_object_properties(unittest.TestCase):
         for mat in nmm.AvailableMaterials().keys():
             print(mat)
             test_mat = nmm.Material(
-                mat, temperature_in_K=300, pressure_in_Pa=5e6)
+                mat, temperature=300, pressure_in_Pa=5e6)
 
             assert isinstance(test_mat.serpent_material, str)
 


### PR DESCRIPTION
Arguments have been renamed to not contain units. This means there is just one way of setting the temperature and reduces the oppertunities for errors. Thanks @eepeterson for the suggestion

pressure_in_Pa -> pressure
temperature_in_K -> temperature
temperature_in_C -> removed

This is a breaking change so the docs and tests have also been updated.

The tutorial videos might need to be remade, but that can be done with another PR