### PR TITLE
adding more information to the verbose printing

### DIFF
--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -353,18 +353,23 @@ def zaid_to_isotope(zaid: str) -> str:
 
 def AddMaterialFromDir(directory: str, verbose: bool = True):
     """Add materials to the internal library from a directory of json files"""
+    if verbose is True:
+        print('searching directory', directory)
     for filename in Path(directory).rglob("*.json"):
+        if verbose is True:
+            print('loading', filename)
         AddMaterialFromFile(filename, verbose)
 
 
 def AddMaterialFromFile(filename: str, verbose: Optional[bool] = True) -> None:
     """Add materials to the internal library from a json file"""
-    with open(filename, "r") as f:
-        new_data = json.load(f)
-        material_dict.update(new_data)
     if verbose:
         print("Added materials to library from", filename)
-        print(sorted(list(material_dict.keys())))
+    with open(filename, "r") as f:
+        new_data = json.load(f)
+        if verbose:
+            print('Added material', list(new_data.keys()))
+        material_dict.update(new_data)
 
 
 def AvailableMaterials() -> dict:

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -351,11 +351,15 @@ def zaid_to_isotope(zaid: str) -> str:
     return symbol + str(int(a))
 
 
-def AddMaterialFromDir(directory: str, verbose: bool = True):
+def AddMaterialFromDir(directory: str, verbose: bool = True, recursive=True):
     """Add materials to the internal library from a directory of json files"""
     if verbose is True:
         print('searching directory', directory)
-    for filename in Path(directory).rglob("*.json"):
+    if recursive:
+        filelist = Path(directory).rglob("*.json")
+    else:
+        filelist = Path(directory).glob("*.json")
+    for filename in filelist:
         if verbose is True:
             print('loading', filename)
         AddMaterialFromFile(filename, verbose)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.3.2",
+    version="0.3.3",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="mail@jshimwell.com",


### PR DESCRIPTION

A user reported AddMaterialFromDir was not working and while I've tried to reproduce the error I just can't figure out what is going wrong.

I've added some more more information to the verbose printing of AddMaterialFromDir

```nmm.AddMaterialFromDir('/home/jshim/nmm_example', verbose=True)```

will now print the folder being searched for json files and the individual files themselves, this will help in the event that an individual file is breaking on when loaded up

Another option has been added called ```recursive``` so this can control if the sub folders are searched for json files.

search folder and subfolder
```nmm.AddMaterialFromDir('/home/jshim/nmm_example', verbose=True, recursive=True)```

search just this folder
```nmm.AddMaterialFromDir('/home/jshim/nmm_example', verbose=True, recursive=False)```

