### PR TITLE
adding extra line at end of mat card

### DIFF
--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -300,7 +300,7 @@ def make_mcnp_material(mat) -> str:
 
     mat_card = mat_card + add_additional_end_lines('mcnp', mat)
 
-    return "\n".join(mat_card)
+    return "\n".join(mat_card) + '\n'
 
 
 def make_shift_material(mat) -> str:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="neutronics_material_maker",
-    version="0.3.3",
+    version="0.3.4",
     summary="Package for making material cards for neutronics codes",
     author="neutronics_material_maker development team",
     author_email="mail@jshimwell.com",

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -208,7 +208,7 @@ class test_object_properties(unittest.TestCase):
         )
         line_by_line_material = test_material.mcnp_material.split("\n")
 
-        assert len(line_by_line_material) == 12
+        assert len(line_by_line_material) == 13
 
         assert line_by_line_material[0].split()[0] == "c"
         assert line_by_line_material[0].split()[1] == "Nb3Sn"
@@ -239,7 +239,7 @@ class test_object_properties(unittest.TestCase):
         )
         line_by_line_material = test_material.mcnp_material.split("\n")
 
-        assert len(line_by_line_material) == 12
+        assert len(line_by_line_material) == 13
 
         assert line_by_line_material[0].split()[0] == "c"
         assert line_by_line_material[0].split()[1] == "Nb3Sn"
@@ -271,7 +271,7 @@ class test_object_properties(unittest.TestCase):
         )
         line_by_line_material = test_material.mcnp_material.split("\n")
 
-        assert len(line_by_line_material) == 12
+        assert len(line_by_line_material) == 13
 
         assert line_by_line_material[0].split()[0] == "c"
         assert line_by_line_material[0].split()[1] == "test2"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ class test_object_properties(unittest.TestCase):
             }
         )
 
-        assert test_mat3.mcnp_material.split('\n')[-1] == 'extra_mcnp_lin'
+        assert test_mat3.mcnp_material.split('\n')[-2] == 'extra_mcnp_lin'
         assert test_mat3.serpent_material.split(
             '\n')[-1] == 'extra_serpent_lin'
         assert test_mat3.fispact_material.split(
@@ -59,7 +59,7 @@ class test_object_properties(unittest.TestCase):
             material_id=1,
             additional_end_lines={'mcnp': ['        mt24 lwtr.01']}
         )
-        assert test_mat.mcnp_material.split('\n')[-1] == '        mt24 lwtr.01'
+        assert test_mat.mcnp_material.split('\n')[-2] == '        mt24 lwtr.01'
 
     def test_additional_lines_shift(self):
         test_mat = nmm.Material.from_library(
@@ -113,8 +113,8 @@ class test_object_properties(unittest.TestCase):
         nmm.AddMaterialFromFile("extra_material_1.json")
 
         test_mat = nmm.Material.from_library('mat_with_add_line')
-        assert test_mat.mcnp_material.split('\n')[-2] == 'coucou1'
-        assert test_mat.mcnp_material.split('\n')[-1] == 'coucou2'
+        assert test_mat.mcnp_material.split('\n')[-3] == 'coucou1'
+        assert test_mat.mcnp_material.split('\n')[-2] == 'coucou2'
 
     def test_incorrect_additional_lines_code_name(self):
 


### PR DESCRIPTION
This adds an extra \n line to the end of MCNP materials to avoid the next material starting on the same line